### PR TITLE
Add icon for m4a audio files

### DIFF
--- a/utils/getFileIcon.ts
+++ b/utils/getFileIcon.ts
@@ -41,6 +41,7 @@ const extensions = {
   flac: icons.audio,
   oga: icons.audio,
   opus: icons.audio,
+  m4a: icons.audio,
 
   avi: icons.video,
   flv: icons.video,


### PR DESCRIPTION
`m4a` is an MPEG 4 filename extension for audio.
https://en.wikipedia.org/wiki/MPEG-4_Part_14#Filename_extensions