### PR TITLE
Fix index page 500 error

### DIFF
--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -8,10 +8,11 @@ import { compareHashedToken } from '../../utils/tools'
 
 const basePath = pathPosix.resolve('/', apiConfig.base)
 const encodePath = (path: string) => {
-  const encodedPath = pathPosix.join(basePath, pathPosix.resolve('/', path))
+  let encodedPath = pathPosix.join(basePath, pathPosix.resolve('/', path))
   if (encodedPath === '/' || encodedPath === '') {
     return ''
   }
+  encodedPath = encodedPath.replace(/\/$/, '')
   return `:${encodeURIComponent(encodedPath)}`
 }
 


### PR DESCRIPTION
The sensitive MS drive API can not handle trailing slash in the folder path.
Removing it fixes the index page 500 problem.

Closes #102