### PR TITLE
add docker build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Install dependencies only when needed
+FROM node:alpine AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Rebuild the source code only when needed
+FROM node:alpine AS builder
+WORKDIR /app
+COPY . .
+COPY --from=deps /app/node_modules ./node_modules
+RUN npm run build && npm install --production --ignore-scripts --prefer-offline
+
+# Production image, copy all the files and run next
+FROM node:alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV production
+
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nextjs -u 1001
+
+# You only need to copy next.config.js if you are NOT using the default configuration
+# COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+USER nextjs
+
+EXPOSE 3000
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry.
+# ENV NEXT_TELEMETRY_DISABLED 1
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
change configs in `config` folder and then use `docker build -t onedrive-index .` to build image. 

Then it is possible to use the following to run onedrive-vercel-index 

- `docker run -p 3000:3000 --restart always -e REFRESH_TOKEN=... -e CLIENT_SECRET=... -e ACCESS_TOKEN=... onedrive-index`
- with docker-compose: place the following `docker-compose.yml` file and then run `docker-compose up -d`

```yaml
version: "2.0"
services:
  onedrive-index:
    container_name: onedrive-index
    restart: always
    ports:
      - "3000:3000"
    environment:
      - CLIENT_SECRET=...
      - REFRESH_TOKEN=...
      - ACCESS_TOKEN=...
    image: onedrive-index
```