### PR TITLE
add Dockerfile and the workflow file of Github Action

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,37 @@
+name: build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          buildx-version: latest
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login Docker registry (ghcr.io)
+        run: |-
+          # login to Github ghcr.io
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - name: Build & push docker image
+        run: |-
+          # build docker image
+          docker buildx build \
+              --cache-from "type=local,src=/tmp/.buildx-cache" \
+              --cache-to "type=local,dest=/tmp/.buildx-cache" \
+              --platform linux/amd64 \
+              --tag ghcr.io/$GITHUB_ACTOR/onedrive-vercel-index \
+              --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Install dependencies only when needed
+FROM node:alpine AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Rebuild the source code only when needed
+FROM node:alpine AS builder
+WORKDIR /app
+COPY . .
+COPY --from=deps /app/node_modules ./node_modules
+# bug: https://github.com/webpack/webpack/issues/14532#issuecomment-947515866
+ENV NODE_OPTIONS=--openssl-legacy-provider
+RUN npm run build && npm install --production --ignore-scripts --prefer-offline
+
+# Production image, copy all the files and run next
+FROM node:alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV production
+
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nextjs -u 1001
+
+# You only need to copy next.config.js if you are NOT using the default configuration
+# COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+USER nextjs
+
+EXPOSE 3000
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry.
+# ENV NEXT_TELEMETRY_DISABLED 1
+
+CMD ["npm", "run", "start"] 


### PR DESCRIPTION
今晚发现了这个不错的项目，看了下好像不止我自己有脱离vercel自建的需求，随手帮忙加个workflow

- Dockerfile来自[Dockerfile for onedrive-vercel-index](https://gist.github.com/aidenlx/882dae41f2dd8522c89c714df8fc113a)，修了一个导致失败的bug
- 目前buildx仅添加了amd64的target，将来可以考虑加个arm64，不过加arm64之后build速度会非常慢，所以我这里暂时没加，可以进一步讨论
- 似乎目前这个项目依然在初步迭代所以说还没有固定版本号？这个workflow我trigger用的`workflow_dispatch`，目前的现状来看以后发版需要手动去触发一下workflow，将来有版本号的话可以加个on tag的trigger。
- Docker Registry用的是ghcr.io <del>dockerhub已经垃圾到不想再去考虑了</del>