### PR TITLE
Fix 500 when setting root as public root

### DIFF
--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -91,8 +91,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
     }
 
+    const requestPath = encodePath(path)
     // Handle response from OneDrive API
-    const requestUrl = `${apiConfig.driveApi}/root${encodePath(path)}`
+    const requestUrl = `${apiConfig.driveApi}/root${requestPath}`
+    // Whether path is root, which requires some special treatment
+    const isRoot = requestPath === ''
 
     // Go for file raw download link and query with only temporary link parameter
     if (raw) {
@@ -124,7 +127,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     })
 
     if ('folder' in identityData) {
-      const { data: folderData } = await axios.get(`${requestUrl}:/children`, {
+      const { data: folderData } = await axios.get(`${requestUrl}${isRoot ? '': ':'}/children`, {
         headers: { Authorization: `Bearer ${accessToken}` },
         params: next
           ? {


### PR DESCRIPTION
When listing root children, the path need to omit a colon

See https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_list_children?view=odsp-graph-online#list-children-in-the-root-of-the-current-users-drive

Close #124 , close #157 