### PR TITLE
Selecting to download support for current directory

### DIFF
--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -209,7 +209,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
 
     // File selection
     const genTotalSelected = (selected: {[key: string]: boolean}) => {
-      const selectInfo = children.map((c :any) => Boolean(selected[c.id]))
+      const selectInfo = children.filter((c :any) => !c.folder).map((c :any) => Boolean(selected[c.id]))
       const [hasT, hasF] = [selectInfo.some(i => i), selectInfo.some(i => !i)]
       console.log(hasT, hasF)
       return hasT && hasF ? 1 : (!hasF ? 2 : 0)
@@ -230,7 +230,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
         setSelected({})
         setTotalSelected(0)
       } else {
-        setSelected(Object.fromEntries(children.map((c :any) => [c.id, true])))
+        setSelected(Object.fromEntries(children.filter((c :any) => !c.folder).map((c :any) => [c.id, true])))
         setTotalSelected(2)
       }
     }
@@ -239,7 +239,9 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
     const handleDownloadSelected = () => {
       const folderName = path.substr(path.lastIndexOf('/') + 1)
       const folder = folderName ? folderName : undefined
-      const files = children.filter((c: any) => selected[c.id])
+      const files = children
+        .filter((c :any) => !c.folder)
+        .filter((c: any) => selected[c.id])
         .map((c: any) => ({ name: c.name, url: c['@microsoft.graph.downloadUrl'] }))
       saveFiles(files, folder)
     }
@@ -370,11 +372,13 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
               </div>
             )}
             <div className="md:flex dark:text-gray-400 hidden p-1 text-gray-700">
-              <Checkbox
-                checked={selected[c.id] ? 2 : 0}
-                onChange={() => toggleItemSelected(c.id)}
-                title={"Select file"}
-              />
+              {c.folder ? '' : (
+                <Checkbox
+                  checked={selected[c.id] ? 2 : 0}
+                  onChange={() => toggleItemSelected(c.id)}
+                  title="Select file"
+                />
+              )}
             </div>
           </div>
         ))}

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -4,7 +4,7 @@ import emojiRegex from 'emoji-regex'
 import { useClipboard } from 'use-clipboard-copy'
 
 import { ParsedUrlQuery } from 'querystring'
-import { FunctionComponent, useEffect, useRef, useState } from 'react'
+import { FunctionComponent, MouseEventHandler, useEffect, useRef, useState } from 'react'
 import { ImageDecorator } from 'react-viewer/lib/ViewerProps'
 
 import { useRouter } from 'next/router'
@@ -111,8 +111,14 @@ const Checkbox: FunctionComponent<{
       }
     }
   }, [ref, checked, indeterminate])
-  const handleClick = () => {
-    if (ref.current) ref.current.click()
+  const handleClick: MouseEventHandler = (e) => {
+    if (ref.current) {
+      if (e.target === ref.current) {
+        e.stopPropagation()
+      } else {
+        ref.current.click()
+      }
+    }
   }
 
   return (

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -100,7 +100,7 @@ const FileListItem: FunctionComponent<{
 }
 
 const Checkbox: FunctionComponent<{
-  checked: 0|1|2, onChange: () => void, title: string, indeterminate?: boolean
+  checked: 0 | 1 | 2, onChange: () => void, title: string, indeterminate?: boolean
 }> = ({ checked, onChange, title, indeterminate }) => {
   const ref = useRef<HTMLInputElement>(null)
   useEffect(() => {
@@ -111,7 +111,9 @@ const Checkbox: FunctionComponent<{
       }
     }
   }, [ref, checked, indeterminate])
-  const handleClick = () => { ref.current ? ref.current.click() : null }
+  const handleClick = () => {
+    if (ref.current) ref.current.click()
+  }
 
   return (
     <span
@@ -134,8 +136,8 @@ const Checkbox: FunctionComponent<{
 const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) => {
   const [imageViewerVisible, setImageViewerVisibility] = useState(false)
   const [activeImageIdx, setActiveImageIdx] = useState(0)
-  const [selected, setSelected] = useState<{[key: string]: boolean}>({})
-  const [totalSelected, setTotalSelected] = useState<0|1|2>(0)
+  const [selected, setSelected] = useState<{ [key: string]: boolean }>({})
+  const [totalSelected, setTotalSelected] = useState<0 | 1 | 2>(0)
   const [totalGenerating, setTotalGenerating] = useState<boolean>(false)
 
   const router = useRouter()
@@ -209,11 +211,11 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
     })
 
     // Filtered file list helper
-    const getFiles = () => children.filter((c :any) => !c.folder && c.name !== '.password')
+    const getFiles = () => children.filter((c: any) => !c.folder && c.name !== '.password')
 
     // File selection
-    const genTotalSelected = (selected: {[key: string]: boolean}) => {
-      const selectInfo = getFiles().map((c :any) => Boolean(selected[c.id]))
+    const genTotalSelected = (selected: { [key: string]: boolean }) => {
+      const selectInfo = getFiles().map((c: any) => Boolean(selected[c.id]))
       const [hasT, hasF] = [selectInfo.some(i => i), selectInfo.some(i => !i)]
       console.log(hasT, hasF)
       return hasT && hasF ? 1 : (!hasF ? 2 : 0)
@@ -221,10 +223,10 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
     const toggleItemSelected = (id: string) => {
       let val
       if (selected[id]) {
-        val = {...selected}
+        val = { ...selected }
         delete val[id]
       } else {
-        val = {...selected, [id]: true}
+        val = { ...selected, [id]: true }
       }
       setSelected(val)
       setTotalSelected(genTotalSelected(val))
@@ -234,7 +236,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
         setSelected({})
         setTotalSelected(0)
       } else {
-        setSelected(Object.fromEntries(getFiles().map((c :any) => [c.id, true])))
+        setSelected(Object.fromEntries(getFiles().map((c: any) => [c.id, true])))
         setTotalSelected(2)
       }
     }

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -238,14 +238,23 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
 
     // Selected file download
     const handleDownloadSelected = () => {
-      setTotalGenerating(true)
       const folderName = path.substr(path.lastIndexOf('/') + 1)
       const folder = folderName ? folderName : undefined
       const files = children
         .filter((c :any) => !c.folder)
         .filter((c: any) => selected[c.id])
         .map((c: any) => ({ name: c.name, url: c['@microsoft.graph.downloadUrl'] }))
-      saveFiles(files, folder, () => setTotalGenerating(false))
+      if (files.length == 1) {
+        const el = document.createElement('a')
+        el.style.display = 'none'
+        document.body.appendChild(el)
+        el.href = files[0].url
+        el.click()
+        el.remove()
+      } else if (files.length > 1) {
+        setTotalGenerating(true)
+        saveFiles(files, folder, () => setTotalGenerating(false))
+      }
     }
 
     return (

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -270,7 +270,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
         el.remove()
       } else if (files.length > 1) {
         setTotalGenerating(true)
-        const toastId = toast.loading('Downloading selected files. Refresh to cancle, this may take some time...')
+        const toastId = toast.loading('Downloading selected files. Refresh to cancel, this may take some time...')
         downloadMultipleFiles(files, folder)
           .then(() => {
             setTotalGenerating(false)
@@ -318,16 +318,15 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
                     />
                   </svg>
                 </span>
-              ) : totalSelected ? (
-                <span
+              ) : (
+                <button
                   title="Download selected files"
-                  className="hover:bg-gray-300 dark:hover:bg-gray-600 p-2 rounded cursor-pointer"
+                  className="hover:bg-gray-300 dark:hover:bg-gray-600 p-2 rounded cursor-pointer disabled:text-gray-400 disabled:dark:text-gray-600 disabled:hover:bg-white disabled:hover:dark:bg-gray-900"
+                  disabled={totalSelected === 0}
                   onClick={handleSelectedDownload}
                 >
                   <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
-                </span>
-              ) : (
-                ''
+                </button>
               )}
             </div>
           </div>

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -208,9 +208,12 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
       }
     })
 
+    // Filtered file list helper
+    const getFiles = () => children.filter((c :any) => !c.folder && c.name !== '.password')
+
     // File selection
     const genTotalSelected = (selected: {[key: string]: boolean}) => {
-      const selectInfo = children.filter((c :any) => !c.folder).map((c :any) => Boolean(selected[c.id]))
+      const selectInfo = getFiles().map((c :any) => Boolean(selected[c.id]))
       const [hasT, hasF] = [selectInfo.some(i => i), selectInfo.some(i => !i)]
       console.log(hasT, hasF)
       return hasT && hasF ? 1 : (!hasF ? 2 : 0)
@@ -231,7 +234,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
         setSelected({})
         setTotalSelected(0)
       } else {
-        setSelected(Object.fromEntries(children.filter((c :any) => !c.folder).map((c :any) => [c.id, true])))
+        setSelected(Object.fromEntries(getFiles().map((c :any) => [c.id, true])))
         setTotalSelected(2)
       }
     }
@@ -240,8 +243,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
     const handleDownloadSelected = () => {
       const folderName = path.substr(path.lastIndexOf('/') + 1)
       const folder = folderName ? folderName : undefined
-      const files = children
-        .filter((c :any) => !c.folder)
+      const files = getFiles()
         .filter((c: any) => selected[c.id])
         .map((c: any) => ({ name: c.name, url: c['@microsoft.graph.downloadUrl'] }))
       if (files.length == 1) {

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -68,8 +68,8 @@ const FileListItem: FunctionComponent<{
   const renderEmoji = emojiIcon && !emojiIcon.index
 
   return (
-    <div className="grid items-center grid-cols-11 p-3 space-x-2 cursor-pointer">
-      <div className="md:col-span-7 flex items-center col-span-11 space-x-2 truncate">
+    <div className="grid items-center grid-cols-10 p-3 space-x-2 cursor-pointer">
+      <div className="md:col-span-6 flex items-center col-span-10 space-x-2 truncate">
         {/* <div>{c.file ? c.file.mimeType : 'folder'}</div> */}
         <div className="flex-shrink-0 w-5 text-center">
           {renderEmoji ? (
@@ -176,10 +176,32 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
     return (
       <div className="dark:bg-gray-900 dark:text-gray-100 bg-white rounded shadow">
         <div className="dark:border-gray-700 grid items-center grid-cols-12 p-3 space-x-2 border-b border-gray-200">
-          <div className="md:col-span-7 col-span-12 font-bold">Name</div>
+          <div className="md:col-span-6 col-span-12 font-bold">Name</div>
           <div className="md:block hidden col-span-3 font-bold">Last Modified</div>
           <div className="md:block hidden font-bold">Size</div>
           <div className="md:block hidden font-bold">Actions</div>
+          <div className="md:block hidden font-bold">
+            <div className="md:flex dark:text-gray-400 hidden p-1 text-gray-700">
+              <span
+                title="Select files"
+                className="hover:bg-gray-300 dark:hover:bg-gray-600 p-2 rounded"
+              >
+                <input
+                  className="cursor-pointer form-check-input"
+                  type="checkbox"
+                  value=""
+                  // id="todo"
+                  aria-label="Select files"
+                />
+              </span>
+              <span
+                title="Download selected files"
+                className="hover:bg-gray-300 dark:hover:bg-gray-600 p-2 rounded cursor-pointer"
+              >
+                <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
+              </span>
+            </div>
+          </div>
         </div>
 
         <Toaster
@@ -231,7 +253,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
         {children.map((c: any) => (
           <div className="hover:bg-gray-100 dark:hover:bg-gray-850 grid grid-cols-12" key={c.id}>
             <div
-              className="col-span-11"
+              className="col-span-10"
               onClick={e => {
                 e.preventDefault()
 
@@ -279,6 +301,20 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
                 </a>
               </div>
             )}
+            <div className="md:flex dark:text-gray-400 hidden p-1 text-gray-700">
+              <span
+                title="Select file"
+                className="hover:bg-gray-300 dark:hover:bg-gray-600 p-2 rounded"
+              >
+                <input
+                  className="cursor-pointer form-check-input"
+                  type="checkbox"
+                  value=""
+                  // id="todo"
+                  aria-label="Select file"
+                />
+              </span>
+            </div>
           </div>
         ))}
 

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -262,7 +262,16 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
         el.remove()
       } else if (files.length > 1) {
         setTotalGenerating(true)
-        saveFiles(files, folder).then(() => setTotalGenerating(false))
+        const toastId = toast.loading('Downloading selected files. This may be slow...')
+        saveFiles(files, folder).then(() => {
+          setTotalGenerating(false)
+          toast.dismiss(toastId)
+          toast.success('Finished to download selected files.')
+        }).catch(() => {
+          setTotalGenerating(false)
+          toast.dismiss(toastId)
+          toast.error('Failed to download selected files.')
+        })
       }
     }
 

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -12,7 +12,7 @@ import dynamic from 'next/dynamic'
 
 import { getExtension, getFileIcon, hasKey } from '../utils/getFileIcon'
 import { extensions, preview } from '../utils/getPreviewType'
-import { getBaseUrl, useProtectedSWRInfinite } from '../utils/tools'
+import { getBaseUrl, saveFiles, useProtectedSWRInfinite } from '../utils/tools'
 
 import { VideoPreview } from './previews/VideoPreview'
 import { AudioPreview } from './previews/AudioPreview'
@@ -235,6 +235,15 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
       }
     }
 
+    // Selected file download
+    const handleDownloadSelected = () => {
+      const folderName = path.substr(path.lastIndexOf('/') + 1)
+      const folder = folderName ? folderName : undefined
+      const files = children.filter((c: any) => selected[c.id])
+        .map((c: any) => ({ name: c.name, url: c['@microsoft.graph.downloadUrl'] }))
+      saveFiles(files, folder)
+    }
+
     return (
       <div className="dark:bg-gray-900 dark:text-gray-100 bg-white rounded shadow">
         <div className="dark:border-gray-700 grid items-center grid-cols-12 p-3 space-x-2 border-b border-gray-200">
@@ -250,12 +259,15 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
                 indeterminate={true}
                 title={"Select files"}
               />
-              <span
-                title="Download selected files"
-                className="hover:bg-gray-300 dark:hover:bg-gray-600 p-2 rounded cursor-pointer"
-              >
-                <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
-              </span>
+              {totalSelected ? (
+                <span
+                  title="Download selected files"
+                  className="hover:bg-gray-300 dark:hover:bg-gray-600 p-2 rounded cursor-pointer"
+                  onClick={handleDownloadSelected}
+                >
+                  <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
+                </span>
+              ) : ''}
             </div>
           </div>
         </div>

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -217,7 +217,6 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
     const genTotalSelected = (selected: { [key: string]: boolean }) => {
       const selectInfo = getFiles().map((c: any) => Boolean(selected[c.id]))
       const [hasT, hasF] = [selectInfo.some(i => i), selectInfo.some(i => !i)]
-      console.log(hasT, hasF)
       return hasT && hasF ? 1 : (!hasF ? 2 : 0)
     }
     const toggleItemSelected = (id: string) => {

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -242,7 +242,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
     }
 
     // Selected file download
-    const handleDownloadSelected = () => {
+    const handleSelectedDownload = () => {
       const folderName = path.substr(path.lastIndexOf('/') + 1)
       const folder = folderName ? folderName : undefined
       const files = getFiles()
@@ -257,7 +257,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
         el.remove()
       } else if (files.length > 1) {
         setTotalGenerating(true)
-        saveFiles(files, folder, () => setTotalGenerating(false))
+        saveFiles(files, folder).then(() => setTotalGenerating(false))
       }
     }
 
@@ -302,7 +302,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
                 <span
                   title="Download selected files"
                   className="hover:bg-gray-300 dark:hover:bg-gray-600 p-2 rounded cursor-pointer"
-                  onClick={handleDownloadSelected}
+                  onClick={handleSelectedDownload}
                 >
                   <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
                 </span>

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -407,7 +407,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
               </div>
             )}
             <div className="md:flex dark:text-gray-400 hidden p-1 text-gray-700">
-              {c.folder ? '' : (
+              {c.folder || c.name === '.password' ? '' : (
                 <Checkbox
                   checked={selected[c.id] ? 2 : 0}
                   onChange={() => toggleItemSelected(c.id)}

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -136,6 +136,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
   const [activeImageIdx, setActiveImageIdx] = useState(0)
   const [selected, setSelected] = useState<{[key: string]: boolean}>({})
   const [totalSelected, setTotalSelected] = useState<0|1|2>(0)
+  const [totalGenerating, setTotalGenerating] = useState<boolean>(false)
 
   const router = useRouter()
   const clipboard = useClipboard()
@@ -237,13 +238,14 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
 
     // Selected file download
     const handleDownloadSelected = () => {
+      setTotalGenerating(true)
       const folderName = path.substr(path.lastIndexOf('/') + 1)
       const folder = folderName ? folderName : undefined
       const files = children
         .filter((c :any) => !c.folder)
         .filter((c: any) => selected[c.id])
         .map((c: any) => ({ name: c.name, url: c['@microsoft.graph.downloadUrl'] }))
-      saveFiles(files, folder)
+      saveFiles(files, folder, () => setTotalGenerating(false))
     }
 
     return (
@@ -261,7 +263,29 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
                 indeterminate={true}
                 title={"Select files"}
               />
-              {totalSelected ? (
+              {totalGenerating ? (
+                <span
+                  title="Downloading selected files, refresh page to cancel"
+                  className="p-2 rounded"
+                  role="status"
+                >
+                  <svg
+                    // Use fontawesome far theme via class `svg-inline--fa` to get style `vertical-align` only
+                    // for consistent icon alignment, as class `align-*` cannot satisfy it
+                    className="animate-spin w-4 h-4 inline-block svg-inline--fa"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                </span>
+              ) : (totalSelected ? (
                 <span
                   title="Download selected files"
                   className="hover:bg-gray-300 dark:hover:bg-gray-600 p-2 rounded cursor-pointer"
@@ -269,7 +293,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
                 >
                   <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
                 </span>
-              ) : ''}
+              ) : '')}
             </div>
           </div>
         </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -42,7 +42,7 @@ const Navbar = () => {
 
   return (
     <div className="text-left p-1 bg-white dark:bg-gray-900 sticky top-0 bg-opacity-80 backdrop-blur-md shadow-sm z-[100]">
-      <div className="flex items-center justify-between w-full max-w-4xl mx-auto">
+      <div className="flex items-center justify-between w-full max-w-5xl mx-auto">
         <Toaster />
 
         <Link href="/">

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "axios": "^0.21.1",
         "crypto-js": "^4.1.1",
         "emoji-regex": "^9.2.2",
+        "jszip": "^3.7.1",
         "next": "^11.1.0",
         "preview-office-docs": "^1.0.2",
         "prismjs": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "axios": "^0.21.1",
     "crypto-js": "^4.1.1",
     "emoji-regex": "^9.2.2",
+    "jszip": "^3.7.1",
     "next": "^11.1.0",
     "preview-office-docs": "^1.0.2",
     "prismjs": "^1.23.0",

--- a/pages/[...path].tsx
+++ b/pages/[...path].tsx
@@ -18,7 +18,7 @@ export default function Folders() {
 
       <main className="bg-gray-50 dark:bg-gray-800 flex flex-col flex-1 w-full">
         <Navbar />
-        <div className="w-full max-w-4xl p-4 mx-auto">
+        <div className="w-full max-w-5xl p-4 mx-auto">
           <Breadcrumb query={query} />
           <FileListing query={query} />
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,7 @@ export default function Home() {
 
       <main className="bg-gray-50 dark:bg-gray-800 flex flex-col flex-1 w-full">
         <Navbar />
-        <div className="w-full max-w-4xl p-4 mx-auto">
+        <div className="w-full max-w-5xl p-4 mx-auto">
           <Breadcrumb />
           <FileListing />
         </div>

--- a/utils/tools.ts
+++ b/utils/tools.ts
@@ -129,8 +129,9 @@ export const matchProtectedRoute = (route: string) => {
  * Download multiple files after compressing them into a zip
  * @param files Files to be downloaded
  * @param folder Optional folder name to hold files, otherwise flatten files in the zip
+ * @param onFinish Optional hook triggered after sending generated zip to browser to download
  */
-export const saveFiles = (files: { name: string, url: string }[], folder?: string) => {
+export const saveFiles = (files: { name: string, url: string }[], folder?: string, onFinish?: () => void) => {
   const zip = new JSZip()
   const dir = folder ? zip.folder(folder)! : zip
   files.forEach(({ name, url }) => {
@@ -146,5 +147,8 @@ export const saveFiles = (files: { name: string, url: string }[], folder?: strin
     el.click()
     window.URL.revokeObjectURL(bUrl)
     el.remove()
+    if (onFinish) {
+      onFinish()
+    }
   })
 }

--- a/utils/tools.ts
+++ b/utils/tools.ts
@@ -130,16 +130,25 @@ export const matchProtectedRoute = (route: string) => {
  * @param files Files to be downloaded
  * @param folder Optional folder name to hold files, otherwise flatten files in the zip
  */
-export const saveFiles = async (files: { name: string, url: string }[], folder?: string) => {
+export const downloadMultipleFiles = async (files: { name: string; url: string }[], folder?: string) => {
   const zip = new JSZip()
   const dir = folder ? zip.folder(folder)! : zip
+
+  // Add selected file blobs to zip
   files.forEach(({ name, url }) => {
-    dir.file(name, fetch(url).then(r => r.blob()))
+    dir.file(
+      name,
+      fetch(url).then(r => r.blob())
+    )
   })
+
+  // Create zip file and prepare for download
   const b = await dir.generateAsync({ type: 'blob' })
   const el = document.createElement('a')
   el.style.display = 'none'
   document.body.appendChild(el)
+
+  // Download zip file
   const bUrl = window.URL.createObjectURL(b)
   el.href = bUrl
   el.download = folder ? folder + '.zip' : 'download.zip'

--- a/utils/tools.ts
+++ b/utils/tools.ts
@@ -129,26 +129,21 @@ export const matchProtectedRoute = (route: string) => {
  * Download multiple files after compressing them into a zip
  * @param files Files to be downloaded
  * @param folder Optional folder name to hold files, otherwise flatten files in the zip
- * @param onFinish Optional hook triggered after sending generated zip to browser to download
  */
-export const saveFiles = (files: { name: string, url: string }[], folder?: string, onFinish?: () => void) => {
+export const saveFiles = async (files: { name: string, url: string }[], folder?: string) => {
   const zip = new JSZip()
   const dir = folder ? zip.folder(folder)! : zip
   files.forEach(({ name, url }) => {
     dir.file(name, fetch(url).then(r => r.blob()))
   })
-  dir.generateAsync({ type: 'blob' }).then(b => {
-    const el = document.createElement('a')
-    el.style.display = 'none'
-    document.body.appendChild(el)
-    const bUrl = window.URL.createObjectURL(b)
-    el.href = bUrl
-    el.download = folder ? folder + '.zip' : 'download.zip'
-    el.click()
-    window.URL.revokeObjectURL(bUrl)
-    el.remove()
-    if (onFinish) {
-      onFinish()
-    }
-  })
+  const b = await dir.generateAsync({ type: 'blob' })
+  const el = document.createElement('a')
+  el.style.display = 'none'
+  document.body.appendChild(el)
+  const bUrl = window.URL.createObjectURL(b)
+  el.href = bUrl
+  el.download = folder ? folder + '.zip' : 'download.zip'
+  el.click()
+  window.URL.revokeObjectURL(bUrl)
+  el.remove()
 }


### PR DESCRIPTION
The PR adds a new column (by moving `col-span-1` from filename column to the new column) to provide selection checkbox and download button to download selected files (excluding folders) in the current directory. The files will be compressed into one single zip file and then passed to browser to download. (In the process, data is stored in blobs so there should not be huge memory consumption, but I have not take a benchmark)

The reason why selecting folders is not implemented is that, while recursively go through the folders is difficult according to https://github.com/spencerwooo/onedrive-vercel-index/discussions/136#discussioncomment-1450067 , folders may be password-protected and it seems hard to find a proper way to ask users for the multiply passwords. Anyway, file selecting support should be enough to help people who store tons of files without packaging on the app.

As for pagination, the PR reuse the SWR hook result so pagination should not be broken.

A demo can (still) be found on https://share.myl.moe/

Ref: discussion #136 issue #143