### PR TITLE
Folder download

### DIFF
--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -12,7 +12,7 @@ import dynamic from 'next/dynamic'
 
 import { getExtension, getFileIcon, hasKey } from '../utils/getFileIcon'
 import { extensions, preview } from '../utils/getPreviewType'
-import { getBaseUrl, downloadMultipleFiles, useProtectedSWRInfinite } from '../utils/tools'
+import { getBaseUrl, treeList, downloadMultipleFiles, useProtectedSWRInfinite } from '../utils/tools'
 
 import { VideoPreview } from './previews/VideoPreview'
 import { AudioPreview } from './previews/AudioPreview'
@@ -285,6 +285,13 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
       }
     }
 
+    // Folder recursive download
+    const handleFolderDownload = (path: string) => async () => {
+      for await (const { meta: c, path: p } of treeList(path)) {
+        console.log(p, c)
+      }
+    }
+
     return (
       <div className="dark:bg-gray-900 dark:text-gray-100 bg-white rounded shadow">
         <div className="dark:border-gray-700 grid items-center grid-cols-12 px-3 space-x-2 border-b border-gray-200">
@@ -399,6 +406,13 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
                   }}
                 >
                   <FontAwesomeIcon icon={['far', 'copy']} />
+                </span>
+                <span
+                  title="Download folder"
+                  className="hover:bg-gray-300 dark:hover:bg-gray-600 p-2 rounded cursor-pointer"
+                  onClick={handleFolderDownload(`${path === '/' ? '' : path}/${encodeURIComponent(c.name)}`)}
+                >
+                  <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
                 </span>
               </div>
             ) : (

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -318,7 +318,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
       })()
       setFolderGenerating({ ...folderGenerating, [id]: true })
       const toastId = toast.loading('Downloading folder. Refresh to cancel, this may take some time...')
-      downloadTreelikeMultipleFiles(files, name).then(() => {
+      downloadTreelikeMultipleFiles(files, path, name).then(() => {
         setFolderGenerating({ ...folderGenerating, [id]: false })
         toast.dismiss(toastId)
         toast.success('Finished to download folder.')

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -13,7 +13,11 @@ import dynamic from 'next/dynamic'
 import { getExtension, getFileIcon, hasKey } from '../utils/getFileIcon'
 import { extensions, preview } from '../utils/getPreviewType'
 import {
-  getBaseUrl, traverseFolder, downloadMultipleFiles, useProtectedSWRInfinite, downloadTreelikeMultipleFiles
+  getBaseUrl,
+  traverseFolder,
+  downloadMultipleFiles,
+  useProtectedSWRInfinite,
+  downloadTreelikeMultipleFiles,
 } from '../utils/tools'
 
 import { VideoPreview } from './previews/VideoPreview'
@@ -148,11 +152,7 @@ const Checkbox: FunctionComponent<{
 
 const Downloading: FunctionComponent<{ title: string }> = ({ title }) => {
   return (
-    <span
-      title={title}
-      className="p-2 rounded"
-      role="status"
-    >
+    <span title={title} className="p-2 rounded" role="status">
       <LoadingIcon
         // Use fontawesome far theme via class `svg-inline--fa` to get style `vertical-align` only
         // for consistent icon alignment, as class `align-*` cannot satisfy it
@@ -316,17 +316,21 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
           }
         }
       })()
+
       setFolderGenerating({ ...folderGenerating, [id]: true })
       const toastId = toast.loading('Downloading folder. Refresh to cancel, this may take some time...')
-      downloadTreelikeMultipleFiles(files, path, name).then(() => {
-        setFolderGenerating({ ...folderGenerating, [id]: false })
-        toast.dismiss(toastId)
-        toast.success('Finished to download folder.')
-      }).catch(() => {
-        setFolderGenerating({ ...folderGenerating, [id]: false })
-        toast.dismiss(toastId)
-        toast.error('Failed to download folder.')
-      })
+
+      downloadTreelikeMultipleFiles(files, path, name)
+        .then(() => {
+          setFolderGenerating({ ...folderGenerating, [id]: false })
+          toast.dismiss(toastId)
+          toast.success('Finished downloading folder.')
+        })
+        .catch(() => {
+          setFolderGenerating({ ...folderGenerating, [id]: false })
+          toast.dismiss(toastId)
+          toast.error('Failed to download folder.')
+        })
     }
 
     return (

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -304,7 +304,6 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
 
     // Folder recursive download
     const handleFolderDownload = (path: string, id: string, name?: string) => () => {
-      setFolderGenerating({ ...folderGenerating, [id]: true })
       const files = (async function* () {
         for await (const { meta: c, path: p, isFolder } of treeList(path)) {
           yield {
@@ -315,7 +314,17 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
           }
         }
       })()
-      saveTreeFiles(files, name).then(() => setFolderGenerating({ ...folderGenerating, [id]: false }))
+      setFolderGenerating({ ...folderGenerating, [id]: true })
+      const toastId = toast.loading('Downloading folder. This may be slow...')
+      saveTreeFiles(files, name).then(() => {
+        setFolderGenerating({ ...folderGenerating, [id]: false })
+        toast.dismiss(toastId)
+        toast.success('Finished to download folder.')
+      }).catch(() => {
+        setFolderGenerating({ ...folderGenerating, [id]: false })
+        toast.dismiss(toastId)
+        toast.error('Failed to download folder.')
+      })
     }
 
     return (

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -16,7 +16,7 @@ import { getBaseUrl, treeList, downloadMultipleFiles, useProtectedSWRInfinite, s
 
 import { VideoPreview } from './previews/VideoPreview'
 import { AudioPreview } from './previews/AudioPreview'
-import Loading from './Loading'
+import Loading, { LoadingIcon } from './Loading'
 import FourOhFour from './FourOhFour'
 import Auth from './Auth'
 import TextPreview from './previews/TextPreview'
@@ -139,6 +139,22 @@ const Checkbox: FunctionComponent<{
         ref={ref}
         aria-label={title}
         onChange={onChange}
+      />
+    </span>
+  )
+}
+
+const Downloading: FunctionComponent<{ title: string }> = ({ title }) => {
+  return (
+    <span
+      title={title}
+      className="p-2 rounded"
+      role="status"
+    >
+      <LoadingIcon
+        // Use fontawesome far theme via class `svg-inline--fa` to get style `vertical-align` only
+        // for consistent icon alignment, as class `align-*` cannot satisfy it
+        className="animate-spin w-4 h-4 inline-block svg-inline--fa"
       />
     </span>
   )
@@ -316,23 +332,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
                 title={'Select files'}
               />
               {totalGenerating ? (
-                <span title="Downloading selected files, refresh page to cancel" className="p-2 rounded" role="status">
-                  <svg
-                    // Use fontawesome far theme via class `svg-inline--fa` to get style `vertical-align` only
-                    // for consistent icon alignment, as class `align-*` cannot satisfy it
-                    className="animate-spin w-4 h-4 inline-block svg-inline--fa"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
-                </span>
+                <Downloading title="Downloading selected files, refresh page to cancel" />
               ) : (
                 <button
                   title="Download selected files"

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -12,7 +12,9 @@ import dynamic from 'next/dynamic'
 
 import { getExtension, getFileIcon, hasKey } from '../utils/getFileIcon'
 import { extensions, preview } from '../utils/getPreviewType'
-import { getBaseUrl, treeList, downloadMultipleFiles, useProtectedSWRInfinite, saveTreeFiles } from '../utils/tools'
+import {
+  getBaseUrl, traverseFolder, downloadMultipleFiles, useProtectedSWRInfinite, downloadTreelikeMultipleFiles
+} from '../utils/tools'
 
 import { VideoPreview } from './previews/VideoPreview'
 import { AudioPreview } from './previews/AudioPreview'
@@ -305,7 +307,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
     // Folder recursive download
     const handleFolderDownload = (path: string, id: string, name?: string) => () => {
       const files = (async function* () {
-        for await (const { meta: c, path: p, isFolder } of treeList(path)) {
+        for await (const { meta: c, path: p, isFolder } of traverseFolder(path)) {
           yield {
             name: c?.name,
             url: c ? c['@microsoft.graph.downloadUrl'] : undefined,
@@ -315,8 +317,8 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
         }
       })()
       setFolderGenerating({ ...folderGenerating, [id]: true })
-      const toastId = toast.loading('Downloading folder. This may be slow...')
-      saveTreeFiles(files, name).then(() => {
+      const toastId = toast.loading('Downloading folder. Refresh to cancel, this may take some time...')
+      downloadTreelikeMultipleFiles(files, name).then(() => {
         setFolderGenerating({ ...folderGenerating, [id]: false })
         toast.dismiss(toastId)
         toast.success('Finished to download folder.')

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -3,21 +3,28 @@ import { FunctionComponent } from 'react'
 const Loading: FunctionComponent<{ loadingText: string }> = ({ loadingText }) => {
   return (
     <div className="dark:text-white flex items-center justify-center py-32 space-x-1 rounded">
-      <svg
-        className="animate-spin w-5 h-5 mr-3 -ml-1"
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-      >
-        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-        <path
-          className="opacity-75"
-          fill="currentColor"
-          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-        ></path>
-      </svg>
+      <LoadingIcon className="animate-spin w-5 h-5 mr-3 -ml-1" />
       <div>{loadingText}</div>
     </div>
+  )
+}
+
+// As there is no CSS-in-JS styling system, pass class list to override styles
+export const LoadingIcon: FunctionComponent<{ className?: string }> = ({ className }) => {
+  return (
+    <svg
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
   )
 }
 

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -12,12 +12,7 @@ const Loading: FunctionComponent<{ loadingText: string }> = ({ loadingText }) =>
 // As there is no CSS-in-JS styling system, pass class list to override styles
 export const LoadingIcon: FunctionComponent<{ className?: string }> = ({ className }) => {
   return (
-    <svg
-      className={className}
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
+    <svg className={className} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
       <path
         className="opacity-75"


### PR DESCRIPTION
~~As a draft, the PR adds some utilities for folder download, allowing one-shot access to recursive tree-like file metadata in the listing page.~~

Updated: The PR adds folder download support. It adds download buttons for folders in file listing page. By the download button, the folder can be downloaded as a zip with the same folder structure as it in OneDrive. It also provides utils for one-shot access to recursive tree-like file metadata.

Due to react hook limit (no conditional call or called in loop), this API does not reuse SWR cache (I tried still can not figure out how to, though SWR team is working on it), but fetches `/api` immediately and arranges the responses. It makes the API pretty slow (seconds for 3 level folder). However, if it is for user one-shot action like downloading a folder (#136 #143) or searching once (#151 if combined with some string similarity checking), personally speaking it is acceptable.

Folder download function impl requires some functions included in PR #169 . I will give a more complete impl if the PR is passed.