### PR TITLE
Attempt to support different storage provider

### DIFF
--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -62,7 +62,7 @@ const queryToPath = (query?: ParsedUrlQuery) => {
 }
 
 const FileListItem: FunctionComponent<{
-  fileContent: { id: string; name: string; size: number; file: Object; lastModifiedDateTime: string }
+  fileContent: { id: string; name: string; size: number; file: Object; lastModified: string }
 }> = ({ fileContent: c }) => {
   const emojiIcon = emojiRegex().exec(c.name)
   const renderEmoji = emojiIcon && !emojiIcon.index
@@ -83,7 +83,7 @@ const FileListItem: FunctionComponent<{
         </div>
       </div>
       <div className="md:block dark:text-gray-500 flex-shrink-0 hidden col-span-3 font-mono text-sm text-gray-700">
-        {new Date(c.lastModifiedDateTime).toLocaleString('en-US', {
+        {new Date(c.lastModified).toLocaleString('en-US', {
           year: 'numeric',
           month: '2-digit',
           day: '2-digit',

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -159,9 +159,9 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
     children.forEach((c: any) => {
       if (fileIsImage(c.name)) {
         imagesInFolder.push({
-          src: c['@microsoft.graph.downloadUrl'],
+          src: c.url,
           alt: c.name,
-          downloadUrl: c['@microsoft.graph.downloadUrl'],
+          downloadUrl: c.url,
         })
         imageIndexDict[c.id] = imageIndex
         imageIndex += 1
@@ -273,7 +273,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
                 <a
                   title="Download file"
                   className="hover:bg-gray-300 dark:hover:bg-gray-600 p-2 rounded cursor-pointer"
-                  href={c['@microsoft.graph.downloadUrl']}
+                  href={c.url}
                 >
                   <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
                 </a>
@@ -341,7 +341,7 @@ const FileListing: FunctionComponent<{ query?: ParsedUrlQuery }> = ({ query }) =
 
   if ('file' in responses[0] && responses.length === 1) {
     const { file } = responses[0]
-    const downloadUrl = file['@microsoft.graph.downloadUrl']
+    const downloadUrl = file.url
     const fileName = file.name
     const fileExtension = fileName.slice(((fileName.lastIndexOf('.') - 1) >>> 0) + 2).toLowerCase()
 

--- a/components/previews/AudioPreview.tsx
+++ b/components/previews/AudioPreview.tsx
@@ -47,13 +47,13 @@ export const AudioPreview: FunctionComponent<{ file: any }> = ({ file }) => {
             <div>{file.name}</div>
             <div className="pb-4 text-sm text-gray-500">
               Last modified:{' '}
-              {new Date(file.lastModifiedDateTime).toLocaleString(undefined, {
+              {new Date(file.lastModified).toLocaleString(undefined, {
                 dateStyle: 'short',
                 timeStyle: 'short',
               })}
             </div>
             <ReactPlayer
-              url={file['@microsoft.graph.downloadUrl']}
+              url={file.url}
               controls
               width="100%"
               height="48px"
@@ -74,7 +74,7 @@ export const AudioPreview: FunctionComponent<{ file: any }> = ({ file }) => {
         </div>
       </div>
       <div className="mt-4">
-        <DownloadBtn downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadBtn downloadUrl={file.url} />
       </div>
     </>
   )

--- a/components/previews/CodePreview.tsx
+++ b/components/previews/CodePreview.tsx
@@ -8,7 +8,7 @@ import Loading from '../Loading'
 import DownloadBtn from '../DownloadBtn'
 
 const CodePreview: FunctionComponent<{ file: any }> = ({ file }) => {
-  const { data, error } = useStaleSWR(file['@microsoft.graph.downloadUrl'])
+  const { data, error } = useStaleSWR(file.url)
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -39,7 +39,7 @@ const CodePreview: FunctionComponent<{ file: any }> = ({ file }) => {
         </pre>
       </div>
       <div className="mt-4">
-        <DownloadBtn downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadBtn downloadUrl={file.url} />
       </div>
     </>
   )

--- a/components/previews/EPUBPreview.tsx
+++ b/components/previews/EPUBPreview.tsx
@@ -40,7 +40,7 @@ const EPUBPreview: FunctionComponent<{file: any}> = ({ file }) => {
         <div className="no-scrollbar flex-1 w-full overflow-scroll" ref={epubContainer} style={{ minHeight: '70vh' }}>
           <div style={{ position: 'absolute', width: epubContainerWidth, height: '70vh' }}>
             <ReactReader
-              url={file['@microsoft.graph.downloadUrl']}
+              url={file.url}
               getRendition={(rendition) => fixEpub(rendition)}
               loadingView={<Loading loadingText="Loading EPUB ..." />}
               location={location}
@@ -52,7 +52,7 @@ const EPUBPreview: FunctionComponent<{file: any}> = ({ file }) => {
         </div>
       </div>
       <div className="mt-4">
-        <DownloadBtn downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadBtn downloadUrl={file.url} />
       </div>
     </>
   )

--- a/components/previews/MarkdownPreview.tsx
+++ b/components/previews/MarkdownPreview.tsx
@@ -18,7 +18,7 @@ const MarkdownPreview: FunctionComponent<{ file: any; path: string; standalone?:
   path,
   standalone = true,
 }) => {
-  const { data, error } = useStaleSWR(file['@microsoft.graph.downloadUrl'])
+  const { data, error } = useStaleSWR(file.url)
 
   // The parent folder of the markdown file, which is also the relative image folder
   const parentPath = path.substring(0, path.lastIndexOf('/'))
@@ -100,7 +100,7 @@ const MarkdownPreview: FunctionComponent<{ file: any; path: string; standalone?:
       </div>
       {standalone && (
         <div className="mt-4">
-          <DownloadBtn downloadUrl={file['@microsoft.graph.downloadUrl']} />
+          <DownloadBtn downloadUrl={file.url} />
         </div>
       )}
     </>

--- a/components/previews/OfficePreview.tsx
+++ b/components/previews/OfficePreview.tsx
@@ -14,10 +14,10 @@ const OfficePreview: FunctionComponent<{ file: any }> = ({ file }) => {
   return (
     <>
       <div className="overflow-scroll shadow" ref={docContainer} style={{ maxHeight: '90vh' }}>
-        <Preview url={encodeURIComponent(file['@microsoft.graph.downloadUrl'])} width={docContainerWidth.toString()} height="800" />
+        <Preview url={encodeURIComponent(file.url)} width={docContainerWidth.toString()} height="800" />
       </div>
       <div className="mt-4">
-        <DownloadBtn downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadBtn downloadUrl={file.url} />
       </div>
     </>
   )

--- a/components/previews/PDFPreview.tsx
+++ b/components/previews/PDFPreview.tsx
@@ -32,7 +32,7 @@ const PDFPreview: FunctionComponent<{ file: any }> = ({ file }) => {
         <div className="no-scrollbar flex-1 w-full overflow-scroll" ref={pdfContainter} style={{ maxHeight: '80vh' }}>
           <Document
             className="dark:bg-gray-800 bg-gray-100"
-            file={file['@microsoft.graph.downloadUrl']}
+            file={file.url}
             onLoadSuccess={onDocumentLoadSuccess}
             loading={<Loading loadingText={loadingText} />}
             onLoadProgress={({ loaded, total }) => {
@@ -85,7 +85,7 @@ const PDFPreview: FunctionComponent<{ file: any }> = ({ file }) => {
         </div>
       </div>
       <div className="mt-4">
-        <DownloadBtn downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadBtn downloadUrl={file.url} />
       </div>
     </>
   )

--- a/components/previews/TextPreview.tsx
+++ b/components/previews/TextPreview.tsx
@@ -6,7 +6,7 @@ import DownloadBtn from '../DownloadBtn'
 import { useStaleSWR } from '../../utils/tools'
 
 const TextPreview: FunctionComponent<{ file: any }> = ({ file }) => {
-  const { data, error } = useStaleSWR(file['@microsoft.graph.downloadUrl'])
+  const { data, error } = useStaleSWR(file.url)
   if (error) {
     return (
       <div className="dark:bg-gray-900 p-3 bg-white rounded shadow">
@@ -28,7 +28,7 @@ const TextPreview: FunctionComponent<{ file: any }> = ({ file }) => {
         <pre className="md:p-3 p-0 overflow-scroll">{data}</pre>
       </div>
       <div className="mt-4">
-        <DownloadBtn downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadBtn downloadUrl={file.url} />
       </div>
     </>
   )

--- a/components/previews/VideoPreview.tsx
+++ b/components/previews/VideoPreview.tsx
@@ -18,7 +18,7 @@ export const VideoPreview: FunctionComponent<{ file: any }> = ({ file }) => {
         <div className="relative" style={{ paddingTop: '56.25%' }}>
           <ReactPlayer
             className="absolute top-0 left-0 w-full h-full"
-            url={file['@microsoft.graph.downloadUrl']}
+            url={file.url}
             controls
             width="100%"
             height="100%"
@@ -38,7 +38,7 @@ export const VideoPreview: FunctionComponent<{ file: any }> = ({ file }) => {
         />
         <a
           className="w-36 focus:outline-none focus:ring focus:ring-blue-300 hover:bg-blue-600 flex items-center justify-center flex-shrink-0 px-4 py-2 mb-2 space-x-4 text-white bg-blue-500 rounded"
-          href={file['@microsoft.graph.downloadUrl']}
+          href={file.url}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -59,7 +59,7 @@ export const VideoPreview: FunctionComponent<{ file: any }> = ({ file }) => {
 
         <a
           className="focus:outline-none focus:ring focus:ring-blue-300 hover:bg-gray-600 flex items-center justify-center px-4 py-2 mb-2 space-x-2 text-white bg-gray-700 rounded"
-          href={`iina://weblink?url=${file['@microsoft.graph.downloadUrl']}`}
+          href={`iina://weblink?url=${file.url}`}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -68,7 +68,7 @@ export const VideoPreview: FunctionComponent<{ file: any }> = ({ file }) => {
         </a>
         <a
           className="focus:outline-none focus:ring focus:ring-blue-300 hover:bg-yellow-500 flex items-center justify-center px-4 py-2 mb-2 space-x-2 text-white bg-yellow-600 rounded"
-          href={`vlc://${file['@microsoft.graph.downloadUrl']}`}
+          href={`vlc://${file.url}`}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -77,7 +77,7 @@ export const VideoPreview: FunctionComponent<{ file: any }> = ({ file }) => {
         </a>
         <a
           className="focus:outline-none focus:ring focus:ring-blue-300 hover:bg-yellow-300 flex items-center justify-center px-4 py-2 mb-2 space-x-2 text-white bg-yellow-400 rounded"
-          href={`potplayer://${file['@microsoft.graph.downloadUrl']}`}
+          href={`potplayer://${file.url}`}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/config/api.json
+++ b/config/api.json
@@ -1,7 +1,10 @@
 {
-  "clientId": "d87bcc39-1750-4ca0-ad54-f8d0efbb2735",
-  "redirectUri": "http://localhost",
-  "base": "/Public",
-  "authApi": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-  "driveApi": "https://graph.microsoft.com/v1.0/me/drive"
+  "provider": "onedrive",
+  "onedrive": {
+    "clientId": "d87bcc39-1750-4ca0-ad54-f8d0efbb2735",
+    "redirectUri": "http://localhost",
+    "base": "/Public",
+    "authApi": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    "driveApi": "https://graph.microsoft.com/v1.0/me/drive"
+  }
 }

--- a/config/api.json
+++ b/config/api.json
@@ -6,5 +6,9 @@
     "base": "/Public",
     "authApi": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
     "driveApi": "https://graph.microsoft.com/v1.0/me/drive"
+  },
+  "nginxAutoindex": {
+    "driveApi": "http://localhost",
+    "base": "/"
   }
 }

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -7,11 +7,14 @@ import { compareHashedToken } from '../../utils/tools'
 
 import { Provider, QueryErrors } from '../../providers/interface'
 import onedrive from '../../providers/onedrive'
+import nginxAutoindex from '../../providers/nginxAutoindex'
 
 const provider: Provider = (() => {
   switch (apiConfig.provider) {
     case 'onedrive':
       return onedrive
+    case 'nginxAutoindex':
+      return nginxAutoindex
     default:
       throw new Error('Unsupported provider')
   }

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -1,47 +1,21 @@
 import axios from 'axios'
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { posix as pathPosix } from 'path'
 
 import apiConfig from '../../config/api.json'
 import siteConfig from '../../config/site.json'
 import { compareHashedToken } from '../../utils/tools'
 
-const basePath = pathPosix.resolve('/', apiConfig.base)
-const encodePath = (path: string) => {
-  let encodedPath = pathPosix.join(basePath, pathPosix.resolve('/', path))
-  if (encodedPath === '/' || encodedPath === '') {
-    return ''
+import { Provider, QueryErrors } from '../../providers/interface'
+import onedrive from '../../providers/onedrive'
+
+const provider: Provider = (() => {
+  switch (apiConfig.provider) {
+    case 'onedrive':
+      return onedrive
+    default:
+      throw new Error('Unsupported provider')
   }
-  encodedPath = encodedPath.replace(/\/$/, '')
-  return `:${encodeURIComponent(encodedPath)}`
-}
-
-// Store access token in memory, cuz Vercel doesn't provide key-value storage natively
-let _access_token = ''
-const getAccessToken = async () => {
-  if (_access_token) {
-    console.log('Fetch token from memory.')
-    return _access_token
-  }
-
-  const body = new URLSearchParams()
-  body.append('client_id', apiConfig.clientId)
-  body.append('redirect_uri', apiConfig.redirectUri)
-  body.append('client_secret', process.env.CLIENT_SECRET ? process.env.CLIENT_SECRET : '')
-  body.append('refresh_token', process.env.REFRESH_TOKEN ? process.env.REFRESH_TOKEN : '')
-  body.append('grant_type', 'refresh_token')
-
-  const resp = await axios.post(apiConfig.authApi, body, {
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-  })
-
-  if (resp.data.access_token) {
-    _access_token = resp.data.access_token
-    return _access_token
-  }
-}
+})()
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { path = '/', raw = false, next = '' } = req.query
@@ -51,8 +25,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   if (typeof path === 'string') {
-    const accessToken = await getAccessToken()
-
     // Handle authentication through .password
     const protectedRoutes = siteConfig.protectedRoutes
     let authTokenPath = ''
@@ -66,15 +38,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Fetch password from remote file content
     if (authTokenPath !== '') {
       try {
-        const token = await axios.get(`${apiConfig.driveApi}/root${encodePath(authTokenPath)}`, {
-          headers: { Authorization: `Bearer ${accessToken}` },
-          params: {
-            select: '@microsoft.graph.downloadUrl,file',
-          },
-        })
+        const data = await provider.query(authTokenPath, { assertFile: true })
 
         // Handle request and check for header 'od-protected-token'
-        const odProtectedToken = await axios.get(token.data['@microsoft.graph.downloadUrl'])
+        const odProtectedToken = await axios.get(data['@microsoft.graph.downloadUrl'])
         // console.log(req.headers['od-protected-token'], odProtectedToken.data.trim())
 
         if (!compareHashedToken(req.headers['od-protected-token'] as string, odProtectedToken.data)) {
@@ -83,7 +50,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         }
       } catch (error: any) {
         // Password file not found, fallback to 404
-        if (error.response.status === 404) {
+        if (error.response?.status === 404) {
           res.status(404).json({ error: "You didn't set a password for your protected folder." })
         }
         res.status(500).end()
@@ -91,70 +58,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
     }
 
-    const requestPath = encodePath(path)
-    // Handle response from OneDrive API
-    const requestUrl = `${apiConfig.driveApi}/root${requestPath}`
-    // Whether path is root, which requires some special treatment
-    const isRoot = requestPath === ''
-
     // Go for file raw download link and query with only temporary link parameter
     if (raw) {
-      const { data } = await axios.get(requestUrl, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-        params: {
-          select: '@microsoft.graph.downloadUrl,folder,file',
-        },
+      const data = await provider.query(path, { assertFile: true }).catch(e => {
+        if (e instanceof Error && e.message === QueryErrors['assertFileErrMsg']) {
+          return null
+        }
+        throw e
       })
-
-      if ('folder' in data) {
+      if (data === null) {
         res.status(400).json({ error: "Folders doesn't have raw download urls." })
         return
       }
-      if ('file' in data) {
-        res.redirect(data['@microsoft.graph.downloadUrl'])
-        return
-      }
-    }
-
-    // Querying current path identity (file or folder) and follow up query childrens in folder
-    // console.log(accessToken)
-
-    const { data: identityData } = await axios.get(requestUrl, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-      params: {
-        select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file',
-      },
-    })
-
-    if ('folder' in identityData) {
-      const { data: folderData } = await axios.get(`${requestUrl}${isRoot ? '': ':'}/children`, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-        params: next
-          ? {
-              select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file',
-              top: siteConfig.maxItems,
-              $skipToken: next,
-            }
-          : {
-              select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file',
-              top: siteConfig.maxItems,
-            },
-      })
-
-      // Extract next page token from full @odata.nextLink
-      const nextPage = folderData['@odata.nextLink']
-        ? folderData['@odata.nextLink'].match(/&\$skiptoken=(.+)/i)[1]
-        : null
-
-      // Return paging token if specified
-      if (nextPage) {
-        res.status(200).json({ folder: folderData, next: nextPage })
-      } else {
-        res.status(200).json({ folder: folderData })
-      }
+      res.redirect(data['@microsoft.graph.downloadUrl'])
       return
     }
-    res.status(200).json({ file: identityData })
+
+    const resData = await provider.query(path, { next: typeof next === 'string' ? next : next[0] })
+    res.status(200).json(resData)
     return
   }
 

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -44,7 +44,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const data = await provider.query(authTokenPath, { assertFile: true })
 
         // Handle request and check for header 'od-protected-token'
-        const odProtectedToken = await axios.get(data['@microsoft.graph.downloadUrl'])
+        const odProtectedToken = await axios.get(data['file'].url)
         // console.log(req.headers['od-protected-token'], odProtectedToken.data.trim())
 
         if (!compareHashedToken(req.headers['od-protected-token'] as string, odProtectedToken.data)) {
@@ -73,7 +73,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         res.status(400).json({ error: "Folders doesn't have raw download urls." })
         return
       }
-      res.redirect(data['@microsoft.graph.downloadUrl'])
+      res.redirect(data['file'].url)
       return
     }
 

--- a/providers/interface.ts
+++ b/providers/interface.ts
@@ -1,0 +1,27 @@
+export interface Provider {
+  // If path is folder, get folder meta and list folder children with their meta;
+  // If path is file, get file meta.
+  query(path: string, options?: QueryOptions & {
+    [key: string]: any // Service-specified optimizing params can be put in it
+  }): Promise<{ file: FileMeta } | { folder: FolderMeta, next?: string }>
+}
+
+export interface QueryOptions {
+  next?: string, // Paging token
+  assertFile?: boolean, // If path is not file, throw error other than processing it further as folder
+}
+
+export const QueryErrors = {
+  assertFileErrMsg: 'Path is not file',
+}
+
+export interface FileMeta {
+  id: string
+  name: string
+  [key: string]: any
+}
+
+export type FolderMeta = {
+  children: FileMeta[]
+  [key: string]: any
+}

--- a/providers/interface.ts
+++ b/providers/interface.ts
@@ -26,6 +26,6 @@ export interface FileMeta {
 }
 
 export type FolderMeta = {
-  children: FileMeta[]
+  value: FileMeta[]
   [key: string]: any
 }

--- a/providers/interface.ts
+++ b/providers/interface.ts
@@ -16,8 +16,12 @@ export const QueryErrors = {
 }
 
 export interface FileMeta {
-  id: string
-  name: string
+  id: string // ID should be GUID, e.g. UUID or path is acceptable
+  name: string // File name
+  size: number; // Byte size
+  lastModified: string // Datetime string with timezone which is parsable by js Date
+  url: string; // Raw url to the file
+  file: any; // Anything but should ne true
   [key: string]: any
 }
 

--- a/providers/nginxAutoindex.ts
+++ b/providers/nginxAutoindex.ts
@@ -52,9 +52,10 @@ export class NginxAutoindexProvider implements Provider {
       }
 
       const folderData = {
-        children: items.map(c => {
+        value: items.map(c => {
           // Generate GUID from path
           c.id = `${path === '/' ? '' : path}/${encodeURIComponent(c.name)}`
+          c.file = true
           return c
         }),
         ...(nextPage === 0 ? {} : { next: nextPage.toString() }),

--- a/providers/nginxAutoindex.ts
+++ b/providers/nginxAutoindex.ts
@@ -58,6 +58,7 @@ export class NginxAutoindexProvider implements Provider {
           // Generate GUID from path
           c.id = `${path === '/' ? '' : path}/${encodeURIComponent(c.name)}`
           c.file = true
+          c.url = url.endsWith('/') ? url + encodeURIComponent(c.name) : `${url}/${encodeURIComponent(c.name)}`
           return NginxAutoindexProvider.formatFileMeta(c)
         }),
         ...(nextPage === 0 ? {} : { next: nextPage.toString() }),

--- a/providers/nginxAutoindex.ts
+++ b/providers/nginxAutoindex.ts
@@ -1,0 +1,77 @@
+/**
+ * Use [nginx autoindex module](https://nginx.org/en/docs/http/ngx_http_autoindex_module.html)
+ * to serve local files.
+ * Minimal example nginx config:
+ * ```nginx
+ * location / {
+ *   root: /var/www/files;
+ *   add_header Access-Control-Allow-Origin *;
+ *   autoindex: on;
+ *   autoindex_format: json;
+ * }
+ * ```
+ * Because nginx cannot (easily) generate a temporary url for files, the provider has no protected route support.
+ * And because nginx autoindex doesnot support paging, though next param works, every time we will fetch all items.
+ */
+
+import axios from 'axios'
+import { posix as pathPosix } from 'path'
+
+import { Provider, QueryErrors, QueryOptions } from './interface'
+import siteConfig from '../config/site.json'
+import allApiConfig from '../config/api.json'
+
+export class NginxAutoindexProvider implements Provider {
+  private apiConfig = allApiConfig.nginxAutoindex
+
+  async query(path: string, options?: QueryOptions) {
+    // Check path is folder or file
+    let isFolder = false
+    const url = this.apiConfig.driveApi + pathPosix.join(this.apiConfig.base, path)
+    // nginx autoindex treats having trailing slash or not differently.
+    // We use it to check path is folder or file.
+    const folderUrl = url.endsWith('/') ? url : url + '/'
+    const folderRes = await axios.get(folderUrl)
+    if (folderRes.status === 200) {
+      isFolder = true
+    }
+
+    if (isFolder) {
+      if (options?.assertFile) {
+        throw new Error(QueryErrors['assertFileErrMsg'])
+      }
+
+      let items = folderRes.data as any[]
+      let nextPage = 0
+      if (options?.next) {
+        nextPage = parseInt(options.next)
+        items = items.slice(nextPage * siteConfig.maxItems)
+      }
+      if (items.length > siteConfig.maxItems) {
+        nextPage += 1
+      }
+
+      const folderData = {
+        children: items.map(c => {
+          // Generate GUID from path
+          c.id = `${path === '/' ? '' : path}/${encodeURIComponent(c.name)}`
+          return c
+        }),
+        ...(nextPage === 0 ? {} : { next: nextPage.toString() }),
+      }
+      return { folder: folderData }
+    } else {
+      const fileRes = await axios.head(url)
+      const meta = {
+        id: path,
+        name: '', // No returned in headers
+        mtime: fileRes.headers['last-modified'],
+        url,
+      }
+      return { file: meta }
+    }
+  }
+}
+
+const nginxAutoindex = new NginxAutoindexProvider()
+export default nginxAutoindex

--- a/providers/nginxAutoindex.ts
+++ b/providers/nginxAutoindex.ts
@@ -31,7 +31,9 @@ export class NginxAutoindexProvider implements Provider {
     // nginx autoindex treats having trailing slash or not differently.
     // We use it to check path is folder or file.
     const folderUrl = url.endsWith('/') ? url : url + '/'
-    const folderRes = await axios.get(folderUrl)
+    const folderRes = await axios.get(folderUrl, {
+      validateStatus: status => (status >= 200 && status < 300) || status === 404,
+    })
     if (folderRes.status === 200) {
       isFolder = true
     }
@@ -56,7 +58,7 @@ export class NginxAutoindexProvider implements Provider {
           // Generate GUID from path
           c.id = `${path === '/' ? '' : path}/${encodeURIComponent(c.name)}`
           c.file = true
-          return c
+          return NginxAutoindexProvider.formatFileMeta(c)
         }),
         ...(nextPage === 0 ? {} : { next: nextPage.toString() }),
       }
@@ -73,6 +75,12 @@ export class NginxAutoindexProvider implements Provider {
       }
       return { file: meta }
     }
+  }
+
+  private static formatFileMeta(data: any) {
+    data.lastModified = data.mtime
+    delete data.mtime
+    return data
   }
 }
 

--- a/providers/nginxAutoindex.ts
+++ b/providers/nginxAutoindex.ts
@@ -64,8 +64,10 @@ export class NginxAutoindexProvider implements Provider {
       const fileRes = await axios.head(url)
       const meta = {
         id: path,
-        name: '', // No returned in headers
-        mtime: fileRes.headers['last-modified'],
+        name: decodeURIComponent(pathPosix.basename(path)), // Filename is not returned, so extract it from path
+        lastModified: fileRes.headers['Last-Modified'],
+        size: parseInt(fileRes.headers['Content-Length']),
+        file: true,
         url,
       }
       return { file: meta }

--- a/providers/onedrive.ts
+++ b/providers/onedrive.ts
@@ -89,6 +89,8 @@ export class OnedriveProvider implements Provider {
         ? folderData['@odata.nextLink'].match(/&\$skiptoken=(.+)/i)[1]
         : null
 
+      folderData.children = folderData.children.map(c => OnedriveProvider.formatFileMeta(c))
+
       // Return paging token if specified
       if (nextPage) {
         return { folder: folderData, next: nextPage }
@@ -96,7 +98,15 @@ export class OnedriveProvider implements Provider {
         return { folder: folderData }
       }
     }
-    return { file: identityData }
+    return { file: OnedriveProvider.formatFileMeta(identityData) }
+  }
+
+  private static formatFileMeta(data: any) {
+    data.url = data['@microsoft.graph.downloadUrl']
+    delete data['@microsoft.graph.downloadUrl']
+    data.lastModified = data.lastModifiedDateTime
+    delete data.lastModifiedDateTime
+    return data
   }
 }
 

--- a/providers/onedrive.ts
+++ b/providers/onedrive.ts
@@ -1,0 +1,104 @@
+import axios from 'axios'
+import { posix as pathPosix } from 'path'
+
+import { Provider, QueryErrors, QueryOptions } from './interface'
+import siteConfig from '../config/site.json'
+import allApiConfig from '../config/api.json'
+
+export class OnedriveProvider implements Provider {
+  private apiConfig = allApiConfig.onedrive ?? allApiConfig
+
+  private basePath = pathPosix.resolve('/', this.apiConfig.base)
+
+  private encodePath(path: string) {
+    let encodedPath = pathPosix.join(this.basePath, pathPosix.resolve('/', path))
+    if (encodedPath === '/' || encodedPath === '') {
+      return ''
+    }
+    encodedPath = encodedPath.replace(/\/$/, '')
+    return `:${encodeURIComponent(encodedPath)}`
+  }
+
+  // Store access token in memory, cuz Vercel doesn't provide key-value storage natively
+  private _access_token = ''
+
+  private async getAccessToken() {
+    if (this._access_token) {
+      console.log('Fetch token from memory.')
+      return this._access_token
+    }
+
+    const body = new URLSearchParams()
+    body.append('client_id', this.apiConfig.clientId)
+    body.append('redirect_uri', this.apiConfig.redirectUri)
+    body.append('client_secret', process.env.CLIENT_SECRET ? process.env.CLIENT_SECRET : '')
+    body.append('refresh_token', process.env.REFRESH_TOKEN ? process.env.REFRESH_TOKEN : '')
+    body.append('grant_type', 'refresh_token')
+
+    const resp = await axios.post(this.apiConfig.authApi, body, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    })
+
+    if (resp.data.access_token) {
+      this._access_token = resp.data.access_token
+      return this._access_token
+    }
+  }
+
+  async query(path: string, options?: QueryOptions) {
+    const accessToken = await this.getAccessToken()
+    const requestPath = this.encodePath(path)
+    // Handle response from OneDrive API
+    const requestUrl = `${this.apiConfig.driveApi}/root${requestPath}`
+    // Whether path is root, which requires some special treatment
+    const isRoot = requestPath === ''
+
+    // Querying current path identity (file or folder) and follow up query children in folder
+    // console.log(accessToken)
+
+    const { data: identityData } = await axios.get(requestUrl, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      params: {
+        select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file',
+      },
+    })
+
+    if ('folder' in identityData) {
+      if (options?.assertFile) {
+        throw new Error(QueryErrors['assertFileErrMsg'])
+      }
+
+      const { data: folderData } = await axios.get(`${requestUrl}${isRoot ? '' : ':'}/children`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        params: options?.next
+          ? {
+            select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file',
+            top: siteConfig.maxItems,
+            $skipToken: options.next,
+          }
+          : {
+            select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file',
+            top: siteConfig.maxItems,
+          },
+      })
+
+      // Extract next page token from full @odata.nextLink
+      const nextPage = folderData['@odata.nextLink']
+        ? folderData['@odata.nextLink'].match(/&\$skiptoken=(.+)/i)[1]
+        : null
+
+      // Return paging token if specified
+      if (nextPage) {
+        return { folder: folderData, next: nextPage }
+      } else {
+        return { folder: folderData }
+      }
+    }
+    return { file: identityData }
+  }
+}
+
+const onedrive = new OnedriveProvider()
+export default onedrive

--- a/providers/onedrive.ts
+++ b/providers/onedrive.ts
@@ -89,7 +89,7 @@ export class OnedriveProvider implements Provider {
         ? folderData['@odata.nextLink'].match(/&\$skiptoken=(.+)/i)[1]
         : null
 
-      folderData.children = folderData.children.map(c => OnedriveProvider.formatFileMeta(c))
+      folderData.value = folderData.value.map(c => OnedriveProvider.formatFileMeta(c))
 
       // Return paging token if specified
       if (nextPage) {


### PR DESCRIPTION
The PR generalized the actions in `pages/api/index.tsx` into interface in `providers/interface.ts`, attempting to make the app support different storage provider other than onedrive only.

The PR already ships a storage provider of nginx autoindex module, which allows to serve local filesystem in the app. Some simple tests (listing, Markdown preview, api?raw=true) have been taken.

The generalization is *not great enough, kinda ugly actually*, and according to discussions #162 , local filesystem mounting is a wonfix. However, I would like to show the implementation to get feedback that whether it is truly required and whether it is possible to implement the feature.