### PR TITLE
fix(pdfpreview): Support for non-latin characters

### DIFF
--- a/components/previews/PDFPreview.tsx
+++ b/components/previews/PDFPreview.tsx
@@ -38,6 +38,10 @@ const PDFPreview: FunctionComponent<{ file: any }> = ({ file }) => {
             onLoadProgress={({ loaded, total }) => {
               setLoadingText(`Loading PDF ${Math.round((loaded / total) * 100)}%`)
             }}
+            options={{
+              cMapUrl: `//cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/cmaps/`,
+              cMapPacked: true,
+            }}
           >
             <Page
               pageNumber={pageNumber}


### PR DESCRIPTION
As mentioned in
https://github.com/wojtekmaj/react-pdf#support-for-non-latin-characters,
pdf.js needs the bundled cMaps files to work.

Fixes #75 