### PR TITLE
Error handling in traversing

### DIFF
--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -297,7 +297,11 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
     // Folder recursive download
     const handleFolderDownload = (path: string, id: string, name?: string) => () => {
       const files = (async function* () {
-        for await (const { meta: c, path: p, isFolder } of traverseFolder(path)) {
+        for await (const { meta: c, path: p, isFolder, error } of traverseFolder(path)) {
+          if (error) {
+            toast.error(`Failed to download folder ${p}: ${error[0]} ${error[1]} Skipped it to continue.`)
+            continue
+          }
           yield {
             name: c?.name,
             url: c ? c['@microsoft.graph.downloadUrl'] : undefined,

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -299,7 +299,7 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
       const files = (async function* () {
         for await (const { meta: c, path: p, isFolder, error } of traverseFolder(path)) {
           if (error) {
-            toast.error(`Failed to download folder ${p}: ${error[0]} ${error[1]} Skipped it to continue.`)
+            toast.error(`Failed to download folder ${p}: ${error.status} ${error.message} Skipped it to continue.`)
             continue
           }
           yield {

--- a/components/MultiFileDownloader.tsx
+++ b/components/MultiFileDownloader.tsx
@@ -168,7 +168,7 @@ export async function* traverseFolder(path: string): AsyncGenerator<
     path: string
     meta: any
     isFolder: boolean
-    error?: [number, string]
+    error?: { status: number; message: string }
   },
   void,
   undefined
@@ -184,13 +184,12 @@ export async function* traverseFolder(path: string): AsyncGenerator<
           try {
             data = await fetcher(`/api?path=${fp}`, hashedToken ?? undefined)
           } catch (error: any) {
-            console.log(error)
             // 4xx errors are identified as handleable errors
             if (Math.floor(error.status / 100) === 4) {
               return {
                 path: fp,
                 isFolder: true,
-                error: [error.status as number, error.message.error as string]
+                error: { status: error.status, message: error.message.error },
               }
             } else {
               throw error
@@ -209,7 +208,12 @@ export async function* traverseFolder(path: string): AsyncGenerator<
       )
     )
 
-    const items = itemLists.flat() as { path: string; meta: any; isFolder: boolean; error?: [number, string] }[]
+    const items = itemLists.flat() as {
+      path: string
+      meta: any
+      isFolder: boolean
+      error?: { status: number; message: string }
+    }[]
     yield * items
     folderPaths = items
       .filter(({ error }) => !error)


### PR DESCRIPTION
The PR adds code to ignore and skip 4xx errors when traversing. 4xx when traversing is either not setting password or `.password` file not found, which are safe to ignore and skip.