### PR TITLE
Support custom url final component name for Notion

### DIFF
--- a/pages/api/name/[name].ts
+++ b/pages/api/name/[name].ts
@@ -1,0 +1,6 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { default as indexHandler } from '..'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  indexHandler(req, res)
+}


### PR DESCRIPTION
Discussion #290

The PR adds a new api route `api/name/[name]`, which forwards the process to `api/index`, to allow users to set any value as the url final component, which is used as filename by services like Notion to define the file type.

To use it, modified `<...>/api?<...>` as `<...>/api/name/<filename>?<...>`.