### PR TITLE
Search on generated index stored in Redis via Redis Lua

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,20 +2,27 @@ module.exports = {
   webpack: (config) => {
     config.resolve.fallback = { fs: false, path: false, stream: false, constants: false };
 
-    // load worker files as a urls with `file-loader`
-    config.module.rules.unshift({
-      test: /pdf\.worker\.(min\.)?js/,
-      use: [
-        {
-          loader: "file-loader",
-          options: {
-            name: "[contenthash].[ext]",
-            publicPath: "_next/static/worker",
-            outputPath: "static/worker"
+    config.module.rules.unshift(
+      // load worker files as a urls with `file-loader`
+      {
+        test: /pdf\.worker\.(min\.)?js/,
+        use: [
+          {
+            loader: "file-loader",
+            options: {
+              name: "[contenthash].[ext]",
+              publicPath: "_next/static/worker",
+              outputPath: "static/worker"
+            }
           }
-        }
-      ]
-    });
+        ]
+      },
+      // load lua script content as a string
+      {
+        test: /\.lua$/,
+        type: 'asset/source'
+      }
+    );
 
     return config;
   },

--- a/redis/search.lua
+++ b/redis/search.lua
@@ -97,7 +97,13 @@ table.sort(name_sim, function(a, b)
 end)
 
 local res = {}
-for i = 1, math.min(tonumber(ARGV[2]), #name_sim) do
+local top = tonumber(ARGV[2])
+if top == 0 then
+  top = #name_sim
+else
+  top = math.min(top, #name_sim)
+end
+for i = 1, top do
   res[i] = name_sim[i][2]
 end
 return res

--- a/redis/search.lua
+++ b/redis/search.lua
@@ -1,0 +1,103 @@
+-- Get string similarity
+local function strsim(a, b)
+  a:gsub('%s+', '')
+  b:gsub('%s+', '')
+
+  if #a == 0 or #b == 0 then
+    if a == b then
+      return 1
+    else
+      return 0
+    end
+  end
+
+  if #a == 1 then
+    if b:find(a) then
+      return 1 / #b
+    else
+      return 0
+    end
+  elseif #b == 1 then
+    if a:find(b) then
+      return 1 / #a
+    else
+      return 0
+    end
+  end
+
+  local a_bigrams = {}
+  local b_bigrams = {}
+  for i = 1, #a do
+    if i <= 1 then
+      -- Affixing
+      a_bigrams[i] = '\x00' .. a:sub(i, i)
+    else
+      a_bigrams[i] = a:sub(i - 1, i)
+    end
+  end
+  for i = 1, #b do
+    if i <= 1 then
+      b_bigrams[i] = '\x00' .. b:sub(i, i)
+    else
+      b_bigrams[i] = b:sub(i - 1, i)
+    end
+  end
+
+  local res = {}
+  for i = 1, #a + 1 do
+    res[i] = {}
+    for j = 1, #b + 1 do
+      res[i][j] = 0
+    end
+  end
+  res[1][1] = 0
+  for i = 1, #a do
+    for j = 1, #b do
+      local m;
+      if a_bigrams[i] == b_bigrams[j] then
+        m = 1
+      elseif b_bigrams[j]:find(a_bigrams[i]:sub(1, 1)) or b_bigrams[j]:find(a_bigrams[i]:sub(2, 2)) then
+        m = 0.5
+      else
+        m = 0
+      end
+      res[i + 1][j + 1] = math.max(res[i][j] + m, res[i][j + 1], res[i + 1][j])
+    end
+  end
+  local r1 = res[#a + 1][#b + 1] / math.max(#a, #b)
+
+  local ar2 = 0
+  for i = 1, #a do
+    if b:find(a:sub(i, i)) then
+      ar2 = ar2 + 1
+    end
+  end
+  ar2 = ar2 / #a
+  local br2 = 0
+  for i = 1, #b do
+    if a:find(b:sub(i, i)) then
+      br2 = br2 + 1
+    end
+  end
+  local r2 = math.max(ar2, br2)
+
+  return r1 * 0.9 + r2 * 0.1
+end
+
+local names = redis.call('hgetall', KEYS[1])
+local name_sim = {}
+for i = 1, #names / 2 do
+  local sim = {}
+  sim[1] = strsim(names[i * 2 - 1], ARGV[1])
+  sim[2] = names[i * 2]
+  name_sim[i] = sim
+end
+table.sort(name_sim, function(a, b)
+  return a[1] > b[1]
+end)
+
+local res = {}
+for i = 1, math.min(tonumber(ARGV[2]), #name_sim) do
+  res[i] = name_sim[i][2]
+end
+return res

--- a/types/ioredis.d.ts
+++ b/types/ioredis.d.ts
@@ -1,0 +1,7 @@
+import 'ioredis'
+
+declare module 'ioredis' {
+  interface Commands {
+    searchIndex: (key: string, q: string, top: number) => Promise<string[]>
+  }
+}

--- a/types/search.d.ts
+++ b/types/search.d.ts
@@ -1,0 +1,4 @@
+declare module '*/search.lua' {
+  const searchLua: string
+  export default searchLua
+}

--- a/utils/searchIndex.ts
+++ b/utils/searchIndex.ts
@@ -14,5 +14,5 @@ kv.defineCommand('searchIndex', {
  * @returns OneDrive item IDs
  */
 export default async function searchIndex(q: string): Promise<string[]> {
-  return await kv.searchIndex('index', q, siteConfig.maxItems)
+  return await kv.searchIndex('index', q, siteConfig.maxItems ?? 0)
 }

--- a/utils/searchIndex.ts
+++ b/utils/searchIndex.ts
@@ -1,0 +1,18 @@
+import Redis from 'ioredis'
+import siteConfig from '../config/site.config'
+import searchLua from '../redis/search.lua'
+
+const kv = new Redis(process.env.REDIS_URL)
+kv.defineCommand('searchIndex', {
+  numberOfKeys: 1,
+  lua: searchLua,
+})
+
+/**
+ * Search in the index stored in Redis
+ * @param q Query string
+ * @returns OneDrive item IDs
+ */
+export default async function searchIndex(q: string): Promise<string[]> {
+  return await kv.searchIndex('index', q, siteConfig.maxItems)
+}


### PR DESCRIPTION
The PR will provide a new search system: generating index and storing it into Redis via scheduled tasks, then searching on it via Redis Lua support (running Lua on Redis servers) (included in Upstash). This will allow us to define custom string comparing algorithm and may improve CJK search experience.

Pending tasks:

- [x] Search algorithm in Lua
  - [x] get, compute, sort, limit, return
  - [x] Handle multiple items with the same filename
- [ ] Integrated with current search API
- [ ] Scheduled task script to generate index (with ability to exclude/include specified dirs)

It takes key `index` to store index, which is a hash (a.k.a. map) currently mapping names (only filename) to OneDrive item ID(s).

Ref: legacy PR #230