### PR TITLE
Avoid opening browser search box in Chrome when pressing Ctrl+K

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -21,12 +21,12 @@ const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false)
 
   const [searchOpen, setSearchOpen] = useState(false)
-  const openSearchBox = (e: KeyboardEvent) => {
-    setSearchOpen(true)
-    e.preventDefault()
-  }
+  const openSearchBox = () => setSearchOpen(true)
 
-  useHotkeys(`${os === 'mac' ? 'cmd' : 'ctrl'}+k`, openSearchBox)
+  useHotkeys(`${os === 'mac' ? 'cmd' : 'ctrl'}+k`, e => {
+    openSearchBox()
+    e.preventDefault()
+  })
 
   useEffect(() => {
     const storedToken = () => {

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -21,7 +21,10 @@ const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false)
 
   const [searchOpen, setSearchOpen] = useState(false)
-  const openSearchBox = () => setSearchOpen(true)
+  const openSearchBox = (e: KeyboardEvent) => {
+    setSearchOpen(true)
+    e.preventDefault()
+  }
 
   useHotkeys(`${os === 'mac' ? 'cmd' : 'ctrl'}+k`, openSearchBox)
 


### PR DESCRIPTION
Ref: discussion #346

Ctrl+K opens browser search box to search with default search engine in Chrome by default. The default behavior should be disabled since we use Ctrl+K to search in the app.