### PR TITLE
Fix layout init value

### DIFF
--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -20,7 +20,7 @@ import {
   traverseFolder,
 } from './MultiFileDownloader'
 
-import layouts from './SwitchLayout'
+import { layouts } from './SwitchLayout'
 import Loading, { LoadingIcon } from './Loading'
 import FourOhFour from './FourOhFour'
 import Auth from './Auth'


### PR DESCRIPTION
The `import` of `layouts` seems invalid, which causes the current break of the demo site.