### PR TITLE
Fix thumbnails under OneDrive 世纪互联

### DIFF
--- a/components/FolderGridLayout.tsx
+++ b/components/FolderGridLayout.tsx
@@ -17,11 +17,9 @@ const GridItem = ({ c, path }: { c: OdFolderChildren; path: string }) => {
     'folder' in c
       ? // Folders don't have thumbnails
         null
-      : c.thumbnails
+      : c.thumbnails && c.thumbnails.length > 0
       ? // Most OneDrive versions, including E5 developer, should have thumbnails returned
-        c.thumbnails.length > 0
-        ? c.thumbnails[0].medium.url
-        : null
+        c.thumbnails[0].medium.url
       : // According to OneDrive docs, OneDrive for Business and SharePoint does not
         // (can not retrieve thumbnails via expand). But currently we only see OneDrive 世纪互联 really does not.
         `/api/thumbnail?path=${path}`

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -90,6 +90,23 @@ export async function getAccessToken(): Promise<string> {
   return ''
 }
 
+/**
+ * Match protected routes in site config to get path to required auth token
+ * @param path Path cleaned in advance
+ * @returns Path to required auth token. If not required, return empty string.
+ */
+export function getAuthTokenPath(path: string) {
+  const protectedRoutes = siteConfig.protectedRoutes
+  let authTokenPath = ''
+  for (const r of protectedRoutes) {
+    if (path.startsWith(r)) {
+      authTokenPath = `${r}/.password`
+      break
+    }
+  }
+  return authTokenPath
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   // If method is POST, then the API is called by the client to store acquired tokens
   if (req.method === 'POST') {
@@ -135,14 +152,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   // Handle authentication through .password
-  const protectedRoutes = siteConfig.protectedRoutes
-  let authTokenPath = ''
-  for (const r of protectedRoutes) {
-    if (cleanPath.startsWith(r)) {
-      authTokenPath = `${r}/.password`
-      break
-    }
-  }
+  const authTokenPath = getAuthTokenPath(cleanPath)
 
   // Fetch password from remote file content
   if (authTokenPath !== '') {

--- a/pages/api/thumbnail.ts
+++ b/pages/api/thumbnail.ts
@@ -1,0 +1,60 @@
+import type { OdThumbnail } from '../../types'
+
+import { posix as pathPosix } from 'path'
+
+import axios from 'axios'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import { encodePath, getAccessToken, getAuthTokenPath } from '.'
+import apiConfig from '../../config/api.config'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // Get access token from storage
+  const accessToken = await getAccessToken()
+
+  // Get item thumbnails by its path since we will later check if it is protected
+  const { path = '' } = req.query
+
+  // Sometimes the path parameter is defaulted to '[...path]' which we need to handle
+  if (path === '[...path]') {
+    res.status(400).json({ error: 'No path specified.' })
+    return
+  }
+  // If the path is not a valid path, return 400
+  if (typeof path !== 'string') {
+    res.status(400).json({ error: 'Path query invalid.' })
+    return
+  }
+  const cleanPath = pathPosix.resolve('/', pathPosix.normalize(path))
+
+  // Check if the path is protected
+  const authTokenPath = getAuthTokenPath(cleanPath)
+
+  // Currently protected paths are rejected to avoid file content leak
+  if (authTokenPath) {
+    res.status(404).json({ error: 'Protected pathes are not allowed.' })
+    return
+  }
+
+  const requestPath = encodePath(cleanPath)
+  // Handle response from OneDrive API
+  const requestUrl = `${apiConfig.driveApi}/root${requestPath}`
+  // Whether path is root, which requires some special treatment
+  const isRoot = requestPath === ''
+
+  try {
+    const { data } = await axios.get(`${requestUrl}${isRoot ? '' : ':'}/thumbnails`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+
+    const thumbnailUrl = data.value && data.value.length > 0 ? (data.value[0] as OdThumbnail).medium.url : null
+    if (thumbnailUrl) {
+      res.redirect(thumbnailUrl)
+    } else {
+      res.status(400).json({ error: "The item doesn't have a valid thumbnail." })
+    }
+  } catch (error: any) {
+    res.status(error.response.status).json({ error: error.response.data })
+  }
+  return
+}


### PR DESCRIPTION
Ref: discussion #378

The PR adds a new API, `/api/thumbnail`, which redirects to the thumbnail url, to fix thumbnail fetching on OneDrive 世纪互联 which does not support `expand` thumbnails.

For authorization, since thumbnails are related to file content, the new API takes path as arg, and check if it is under any protected route. Currently protected pathes are simply rejected (because the url is passed directly to `<img>`, which can not customize headers). https://stackoverflow.com/questions/34096744/how-should-i-load-images-if-i-use-token-based-authentication may be a solution though I am not sure whether it is worthy.