### PR TITLE
Thumbnails on demand

### DIFF
--- a/components/FolderGridLayout.tsx
+++ b/components/FolderGridLayout.tsx
@@ -12,17 +12,8 @@ import { getReadablePath } from '../utils/getReadablePath'
 import { Checkbox, ChildIcon, Downloading, formatChildName } from './FileListing'
 
 const GridItem = ({ c, path }: { c: OdFolderChildren; path: string }) => {
-  // We use the generated medium thumbnail for rendering preview images
-  const thumbnailUrl =
-    'folder' in c
-      ? // Folders don't have thumbnails
-        null
-      : c.thumbnails && c.thumbnails.length > 0
-      ? // Most OneDrive versions, including E5 developer, should have thumbnails returned
-        c.thumbnails[0].medium.url
-      : // According to OneDrive docs, OneDrive for Business and SharePoint does not
-        // (can not retrieve thumbnails via expand). But currently we only see OneDrive 世纪互联 really does not.
-        `/api/thumbnail?path=${path}`
+  // We use the generated medium thumbnail for rendering preview images (excluding folders)
+  const thumbnailUrl = 'folder' in c ? null : `/api/thumbnail?path=${path}&size=medium`
 
   // Some thumbnails are broken, so we check for onerror event in the image component
   const [brokenThumbnail, setBrokenThumbnail] = useState(false)

--- a/components/previews/AudioPreview.tsx
+++ b/components/previews/AudioPreview.tsx
@@ -1,9 +1,10 @@
 import type { OdFileObject } from '../../types'
-import { FC, useState } from 'react'
+import { FC, useEffect, useRef, useState } from 'react'
 
 import ReactAudioPlayer from 'react-audio-player'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useTranslation } from 'next-i18next'
+import { useRouter } from 'next/router'
 
 import DownloadButtonGroup from '../DownloadBtnGtoup'
 import { DownloadBtnContainer, PreviewContainer } from './Containers'
@@ -18,40 +19,83 @@ enum PlayerState {
 }
 
 const AudioPreview: FC<{ file: OdFileObject }> = ({ file }) => {
+  const { t } = useTranslation()
+  const { asPath } = useRouter()
+
+  const rapRef = useRef<ReactAudioPlayer>(null)
   const [playerStatus, setPlayerStatus] = useState(PlayerState.Loading)
 
-  const { t } = useTranslation()
+  // Render audio thumbnail, and also check for broken thumbnails
+  const thumbnail = `/api/thumbnail?path=${asPath}&size=medium`
+  const [brokenThumbnail, setBrokenThumbnail] = useState(false)
+
+  useEffect(() => {
+    // Manually get the HTML audio element and set onplaying event.
+    // - As the default event callbacks provided by the React component does not guarantee playing state to be set
+    // - properly when the user seeks through the timeline or the audio is buffered.
+    const rap = (rapRef.current as ReactAudioPlayer).audioEl.current
+    if (rap) {
+      rap.oncanplay = () => setPlayerStatus(PlayerState.Ready)
+      rap.onended = () => setPlayerStatus(PlayerState.Paused)
+      rap.onpause = () => setPlayerStatus(PlayerState.Paused)
+      rap.onplay = () => setPlayerStatus(PlayerState.Playing)
+      rap.onplaying = () => setPlayerStatus(PlayerState.Playing)
+      rap.onseeking = () => setPlayerStatus(PlayerState.Loading)
+      rap.onwaiting = () => setPlayerStatus(PlayerState.Loading)
+      rap.onerror = () => setPlayerStatus(PlayerState.Paused)
+    }
+  }, [])
 
   return (
     <>
       <PreviewContainer>
         <div className="flex flex-col space-y-4 md:flex-row md:space-x-4">
-          <div className="flex aspect-square w-full items-center justify-center rounded bg-gray-100 transition-all duration-75 dark:bg-gray-700 md:w-40">
-            {playerStatus === PlayerState.Loading ? (
-              <LoadingIcon className="inline-block h-5 w-5 animate-spin" />
+          <div className="relative flex aspect-square w-full items-center justify-center rounded bg-gray-100 transition-all duration-75 dark:bg-gray-700 md:w-48">
+            <div
+              className={`absolute z-20 flex h-full w-full items-center justify-center transition-all duration-300 ${
+                playerStatus === PlayerState.Loading
+                  ? 'bg-white opacity-80 dark:bg-gray-800'
+                  : 'bg-transparent opacity-0'
+              }`}
+            >
+              <LoadingIcon className="z-10 inline-block h-5 w-5 animate-spin" />
+            </div>
+
+            {!brokenThumbnail ? (
+              <div className="absolute m-4 rounded-full shadow-lg">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  className={`h-full w-full rounded-full object-cover object-top ${
+                    playerStatus === PlayerState.Playing ? 'animate-spin-slow' : ''
+                  }`}
+                  src={thumbnail}
+                  alt={file.name}
+                  onError={() => setBrokenThumbnail(true)}
+                />
+              </div>
             ) : (
               <FontAwesomeIcon
-                className={`h-5 w-5 ${playerStatus === PlayerState.Playing ? 'animate-spin' : ''}`}
+                className={`z-10 h-5 w-5 ${playerStatus === PlayerState.Playing ? 'animate-spin' : ''}`}
                 icon="music"
                 size="2x"
               />
             )}
           </div>
-          <div className="flex w-full flex-col space-y-2">
-            <div>{file.name}</div>
-            <div className="pb-4 text-sm text-gray-500">
-              {t('Last modified:') + ' ' + formatModifiedDateTime(file.lastModifiedDateTime)}
+
+          <div className="flex w-full flex-col justify-between">
+            <div>
+              <div className="mb-2 font-medium">{file.name}</div>
+              <div className="mb-4 text-sm text-gray-500">
+                {t('Last modified:') + ' ' + formatModifiedDateTime(file.lastModifiedDateTime)}
+              </div>
             </div>
 
             <ReactAudioPlayer
               className="h-11 w-full"
               src={file['@microsoft.graph.downloadUrl']}
+              ref={rapRef}
               controls
-              onCanPlay={() => setPlayerStatus(PlayerState.Ready)}
-              onPlay={() => setPlayerStatus(PlayerState.Playing)}
-              onPause={() => setPlayerStatus(PlayerState.Paused)}
-              onError={() => setPlayerStatus(PlayerState.Paused)}
-              onEnded={() => setPlayerStatus(PlayerState.Paused)}
+              preload="auto"
             />
           </div>
         </div>

--- a/components/previews/VideoPreview.tsx
+++ b/components/previews/VideoPreview.tsx
@@ -21,7 +21,7 @@ const VideoPreview: React.FC<{ file: OdFileObject }> = ({ file }) => {
   const { t } = useTranslation()
 
   // OneDrive generates thumbnails for its video files, we pick the thumbnail with the highest resolution
-  const thumbnail = file.thumbnails && file.thumbnails.length > 0 ? file.thumbnails[0].large.url : ''
+  const thumbnail = `/api/thumbnail?path=${asPath}&size=large`
 
   // We assume subtitle files are beside the video with the same name, only webvtt '.vtt' files are supported
   const subtitle = `/api?path=${asPath.replace(getExtension(file.name), 'vtt')}&raw=true`

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -220,7 +220,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       headers: { Authorization: `Bearer ${accessToken}` },
       params: {
         select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file,video,image',
-        $expand: 'thumbnails',
       },
     })
 
@@ -230,13 +229,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         params: next
           ? {
               select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file,video,image',
-              $expand: 'thumbnails',
               top: siteConfig.maxItems,
               $skipToken: next,
             }
           : {
               select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file,video,image',
-              $expand: 'thumbnails',
               top: siteConfig.maxItems,
             },
       })

--- a/pages/api/thumbnail.ts
+++ b/pages/api/thumbnail.ts
@@ -13,8 +13,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const accessToken = await getAccessToken()
 
   // Get item thumbnails by its path since we will later check if it is protected
-  const { path = '' } = req.query
+  const { path = '', size = 'medium' } = req.query
 
+  // Check whether the size is valid - must be one of 'large', 'medium', or 'small'
+  if (size !== 'large' && size !== 'medium' && size !== 'small') {
+    res.status(400).json({ error: 'Invalid size' })
+    return
+  }
   // Sometimes the path parameter is defaulted to '[...path]' which we need to handle
   if (path === '[...path]') {
     res.status(400).json({ error: 'No path specified.' })
@@ -47,7 +52,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       headers: { Authorization: `Bearer ${accessToken}` },
     })
 
-    const thumbnailUrl = data.value && data.value.length > 0 ? (data.value[0] as OdThumbnail).medium.url : null
+    const thumbnailUrl = data.value && data.value.length > 0 ? (data.value[0] as OdThumbnail)[size].url : null
     if (thumbnailUrl) {
       res.redirect(thumbnailUrl)
     } else {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,6 +32,9 @@ module.exports = {
         gray: {
           850: '#222226'
         }
+      },
+      animation: {
+        'spin-slow': 'spin 5s linear infinite',
       }
     }
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,8 +17,8 @@ export type OdFolderObject = {
     folder?: { childCount: number; view: { sortBy: string; sortOrder: 'ascending'; viewType: 'thumbnails' } }
     image?: OdImageFile
     video?: OdVideoFile
-    'thumbnails@odata.context'?: string
-    thumbnails?: Array<OdThumbnail>
+    // 'thumbnails@odata.context'?: string
+    // thumbnails?: Array<OdThumbnail>
   }>
 }
 export type OdFolderChildren = OdFolderObject['value'][number]
@@ -33,8 +33,8 @@ export type OdFileObject = {
   file: { mimeType: string; hashes: { quickXorHash: string; sha1Hash?: string; sha256Hash?: string } }
   image?: OdImageFile
   video?: OdVideoFile
-  'thumbnails@odata.context'?: string
-  thumbnails?: Array<OdThumbnail>
+  // 'thumbnails@odata.context'?: string
+  // thumbnails?: Array<OdThumbnail>
 }
 // A representation of a OneDrive image file. Some images do not return a width and height, so types are optional.
 export type OdImageFile = {


### PR DESCRIPTION
- [x] Removes `$expand: 'thumbnails'` and request all thumbnails on demand
   - This sacrifices thumbnail load time, but increases folder listing requests' performance. (As we are requesting fewer items from the OneDrive API on initial render.)
- [x] Render audio thumbnails in spinning disk.