### PR TITLE
Display extension still when space for filename is not enough

### DIFF
--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'next-i18next'
 import useLocalStorage from '../utils/useLocalStorage'
 import { getPreviewType, preview } from '../utils/getPreviewType'
 import { useProtectedSWRInfinite } from '../utils/fetchWithSWR'
-import { getFileIcon } from '../utils/getFileIcon'
+import { getExtension, getFileIcon } from '../utils/getFileIcon'
 import {
   DownloadingToast,
   downloadMultipleFiles,
@@ -66,9 +66,19 @@ const renderEmoji = (name: string) => {
   const emoji = emojiRegex().exec(name)
   return { render: emoji && !emoji.index, emoji }
 }
-export const formatChildName = (name: string) => {
+const formatChildName = (name: string) => {
   const { render, emoji } = renderEmoji(name)
   return render ? name.replace(emoji ? emoji[0] : '', '').trim() : name
+}
+export const ChildName: FC<{ name: string }> = ({ name }) => {
+  let basename = formatChildName(name)
+  const extension = getExtension(basename)
+  basename = basename.substring(0, basename.length - extension.length)
+  return (
+    <span className="truncate before:float-right before:content-[attr(data-tail)]" data-tail={extension}>
+      {basename}
+    </span>
+  )
 }
 export const ChildIcon: FC<{ child: OdFolderChildren }> = ({ child }) => {
   const { render, emoji } = renderEmoji(child.name)

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -374,11 +374,7 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
 
   if ('file' in responses[0] && responses.length === 1) {
     const file = responses[0].file as OdFileObject
-    const downloadUrl = file['@microsoft.graph.downloadUrl']
-    const fileName = file.name
-    const fileExtension = fileName.slice(((fileName.lastIndexOf('.') - 1) >>> 0) + 2).toLowerCase()
-
-    const previewType = getPreviewType(fileExtension, { video: Boolean(file.video) })
+    const previewType = getPreviewType(getExtension(file.name), { video: Boolean(file.video) })
 
     if (previewType) {
       switch (previewType) {

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -71,12 +71,12 @@ const formatChildName = (name: string) => {
   return render ? name.replace(emoji ? emoji[0] : '', '').trim() : name
 }
 export const ChildName: FC<{ name: string }> = ({ name }) => {
-  let basename = formatChildName(name)
-  const extension = getExtension(basename)
-  basename = basename.substring(0, basename.length - extension.length)
+  const original = formatChildName(name)
+  const extension = getExtension(original)
+  const prename = original.substring(0, original.length - extension.length)
   return (
     <span className="truncate before:float-right before:content-[attr(data-tail)]" data-tail={extension}>
-      {basename}
+      {prename}
     </span>
   )
 }

--- a/components/FolderGridLayout.tsx
+++ b/components/FolderGridLayout.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'next-i18next'
 import { getBaseUrl } from '../utils/getBaseUrl'
 import { formatModifiedDateTime } from '../utils/fileDetails'
 import { getReadablePath } from '../utils/getReadablePath'
-import { Checkbox, ChildIcon, Downloading, formatChildName } from './FileListing'
+import { Checkbox, ChildIcon, ChildName, Downloading } from './FileListing'
 
 const GridItem = ({ c, path }: { c: OdFolderChildren; path: string }) => {
   // We use the generated medium thumbnail for rendering preview images (excluding folders)
@@ -43,7 +43,7 @@ const GridItem = ({ c, path }: { c: OdFolderChildren; path: string }) => {
         <span className="w-5 flex-shrink-0 text-center">
           <ChildIcon child={c} />
         </span>
-        <span className="overflow-hidden truncate">{formatChildName(c.name)}</span>
+        <ChildName name={c.name} />
       </div>
       <div className="truncate text-center font-mono text-xs text-gray-700 dark:text-gray-500">
         {formatModifiedDateTime(c.lastModifiedDateTime)}

--- a/components/FolderListLayout.tsx
+++ b/components/FolderListLayout.tsx
@@ -93,7 +93,7 @@ const FolderListLayout = ({
           key={c.id}
         >
           <Link href={`${path === '/' ? '' : path}/${encodeURIComponent(c.name)}`} passHref>
-            <a className="col-span-10">
+            <a className="col-span-12 md:col-span-10">
               <FileListItem fileContent={c} />
             </a>
           </Link>

--- a/components/FolderListLayout.tsx
+++ b/components/FolderListLayout.tsx
@@ -10,7 +10,7 @@ import { getBaseUrl } from '../utils/getBaseUrl'
 import { humanFileSize, formatModifiedDateTime } from '../utils/fileDetails'
 import { getReadablePath } from '../utils/getReadablePath'
 
-import { Downloading, Checkbox, formatChildName, ChildIcon } from './FileListing'
+import { Downloading, Checkbox, ChildIcon, ChildName } from './FileListing'
 
 const FileListItem: FC<{ fileContent: OdFolderChildren }> = ({ fileContent: c }) => {
   return (
@@ -19,7 +19,7 @@ const FileListItem: FC<{ fileContent: OdFolderChildren }> = ({ fileContent: c })
         <div className="w-5 flex-shrink-0 text-center">
           <ChildIcon child={c} />
         </div>
-        <div className="truncate">{formatChildName(c.name)}</div>
+        <ChildName name={c.name} />
       </div>
       <div className="col-span-3 hidden flex-shrink-0 font-mono text-sm text-gray-700 dark:text-gray-500 md:block">
         {formatModifiedDateTime(c.lastModifiedDateTime)}


### PR DESCRIPTION
Ref: #305

The PR makes the app display filename always with its extension, even when the space is not enough. Ellipsis when overflowing will occurs at the end of the basename. Though someone can still not see the full filename on mobile devices, the extension may help to get information about the files.

DRAWBACK: When screen is resized, sometimes there will be a small gap between the ellipsis and extension, which looks a little strange.