### PR TITLE
Fix relative path of readme image

### DIFF
--- a/components/previews/MarkdownPreview.tsx
+++ b/components/previews/MarkdownPreview.tsx
@@ -25,7 +25,7 @@ const MarkdownPreview: FC<{
   const { t } = useTranslation()
 
   // The parent folder of the markdown file, which is also the relative image folder
-  const parentPath = path.substring(0, path.lastIndexOf('/'))
+  const parentPath = standalone ? path.substring(0, path.lastIndexOf('/')) : path
   // Check if the image is relative path instead of a absolute url
   const isUrlAbsolute = (url: string | string[]) => url.indexOf('://') > 0 || url.indexOf('//') === 0
   // Custom renderer to render images with relative path


### PR DESCRIPTION
在文件夹展示 README 时，如果使用了相对路径的图片。
程序则会在当前路径的父路径寻找文件，导致图片加载失败。

按照逻辑，应当在当前路径寻找文件。

效果预览：[小林家的龙女仆S](https://drive.android99.me/zh-CN/🎬%20视频/小林家的龙女仆S/)

(不确定代码这样修改是否合适 \_(:з」∠)\_)