### PR TITLE
Standalone raw file redirects

### DIFF
--- a/components/CustomEmbedLinkMenu.tsx
+++ b/components/CustomEmbedLinkMenu.tsx
@@ -82,13 +82,13 @@ export default function CustomEmbedLinkMenu({
                 />
                 <h4 className="py-2 text-xs font-medium uppercase tracking-wider">{t('Default')}</h4>
                 <div className="mb-2 rounded border border-gray-400/20 bg-gray-50 p-1 font-mono dark:bg-gray-800">
-                  {`${getBaseUrl()}/api/raw?path=${getReadablePath(path)}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
+                  {`${getBaseUrl()}/api/raw/?path=${getReadablePath(path)}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
                 </div>
                 <h4 className="py-2 text-xs font-medium uppercase tracking-wider">{t('Customised')}</h4>
                 <div className="mb-2 rounded border border-gray-400/20 bg-gray-50 p-1 font-mono dark:bg-gray-800">
                   <span>{`${getBaseUrl()}/api/name/`}</span>
                   <span className="underline decoration-blue-400 decoration-wavy">{name}</span>
-                  <span>{`?path=${getReadablePath(path)}${hashedToken ? `&odpt=${hashedToken}` : ''}`}</span>
+                  <span>{`/?path=${getReadablePath(path)}${hashedToken ? `&odpt=${hashedToken}` : ''}`}</span>
                 </div>
               </div>
 
@@ -97,7 +97,7 @@ export default function CustomEmbedLinkMenu({
                   className="rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 px-4 py-2 text-center text-sm font-medium text-white hover:bg-gradient-to-bl focus:ring-4 focus:ring-cyan-300 dark:focus:ring-cyan-800"
                   onClick={() => {
                     clipboard.copy(
-                      `${getBaseUrl()}/api/name/${name}?path=${getReadablePath(path)}${
+                      `${getBaseUrl()}/api/name/${name}/?path=${getReadablePath(path)}${
                         hashedToken ? `&odpt=${hashedToken}` : ''
                       }`
                     )

--- a/components/CustomEmbedLinkMenu.tsx
+++ b/components/CustomEmbedLinkMenu.tsx
@@ -20,6 +20,7 @@ export default function CustomEmbedLinkMenu({
 }) {
   const { t } = useTranslation()
   const clipboard = useClipboard()
+
   const hashedToken = getStoredToken(path)
 
   const closeMenu = () => setMenuOpen(false)

--- a/components/CustomEmbedLinkMenu.tsx
+++ b/components/CustomEmbedLinkMenu.tsx
@@ -6,6 +6,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useClipboard } from 'use-clipboard-copy'
 
 import { getBaseUrl } from '../utils/getBaseUrl'
+import { getStoredToken } from '../utils/protectedRouteHandler'
+import { getReadablePath } from '../utils/getReadablePath'
 
 export default function CustomEmbedLinkMenu({
   path,
@@ -18,6 +20,8 @@ export default function CustomEmbedLinkMenu({
 }) {
   const { t } = useTranslation()
   const clipboard = useClipboard()
+  const hashedToken = getStoredToken(path)
+
   const closeMenu = () => setMenuOpen(false)
 
   const filename = path.substring(path.lastIndexOf('/') + 1)
@@ -77,13 +81,13 @@ export default function CustomEmbedLinkMenu({
                 />
                 <h4 className="py-2 text-xs font-medium uppercase tracking-wider">{t('Default')}</h4>
                 <div className="mb-2 rounded border border-gray-400/20 bg-gray-50 p-1 font-mono dark:bg-gray-800">
-                  {`${getBaseUrl()}/api?path=${path}&raw=true`}
+                  {`${getBaseUrl()}/api/raw?path=${getReadablePath(path)}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
                 </div>
                 <h4 className="py-2 text-xs font-medium uppercase tracking-wider">{t('Customised')}</h4>
                 <div className="mb-2 rounded border border-gray-400/20 bg-gray-50 p-1 font-mono dark:bg-gray-800">
                   <span>{`${getBaseUrl()}/api/name/`}</span>
                   <span className="underline decoration-blue-400 decoration-wavy">{name}</span>
-                  <span>{`?path=${path}&raw=true`}</span>
+                  <span>{`?path=${getReadablePath(path)}${hashedToken ? `&odpt=${hashedToken}` : ''}`}</span>
                 </div>
               </div>
 
@@ -91,7 +95,11 @@ export default function CustomEmbedLinkMenu({
                 <button
                   className="rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 px-4 py-2 text-center text-sm font-medium text-white hover:bg-gradient-to-bl focus:ring-4 focus:ring-cyan-300 dark:focus:ring-cyan-800"
                   onClick={() => {
-                    clipboard.copy(`${getBaseUrl()}/api/name/${name}?path=${path}&raw=true`)
+                    clipboard.copy(
+                      `${getBaseUrl()}/api/name/${name}?path=${getReadablePath(path)}${
+                        hashedToken ? `&odpt=${hashedToken}` : ''
+                      }`
+                    )
                     toast.success(t('Copied customised link to clipboard.'))
                     closeMenu()
                   }}

--- a/components/DownloadBtnGtoup.tsx
+++ b/components/DownloadBtnGtoup.tsx
@@ -77,7 +77,7 @@ const DownloadButtonGroup = () => {
       <CustomEmbedLinkMenu menuOpen={menuOpen} setMenuOpen={setMenuOpen} path={asPath} />
       <div className="flex flex-wrap justify-center gap-2">
         <DownloadButton
-          onClickCallback={() => window.open(`/api/raw?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`)}
+          onClickCallback={() => window.open(`/api/raw/?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`)}
           btnColor="blue"
           btnText={t('Download')}
           btnIcon="file-download"
@@ -93,7 +93,7 @@ const DownloadButtonGroup = () => {
         <DownloadButton
           onClickCallback={() => {
             clipboard.copy(
-              `${getBaseUrl()}/api/raw?path=${getReadablePath(asPath)}${hashedToken ? `&odpt=${hashedToken}` : ''}`
+              `${getBaseUrl()}/api/raw/?path=${getReadablePath(asPath)}${hashedToken ? `&odpt=${hashedToken}` : ''}`
             )
             toast.success(t('Copied direct link to clipboard.'))
           }}

--- a/components/DownloadBtnGtoup.tsx
+++ b/components/DownloadBtnGtoup.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/router'
 import { getBaseUrl } from '../utils/getBaseUrl'
 import { getReadablePath } from '../utils/getReadablePath'
 import CustomEmbedLinkMenu from './CustomEmbedLinkMenu'
+import { getStoredToken } from '../utils/protectedRouteHandler'
 
 const btnStyleMap = (btnColor?: string) => {
   const colorMap = {
@@ -64,6 +65,8 @@ export const DownloadButton = ({
 
 const DownloadButtonGroup = () => {
   const { asPath } = useRouter()
+  const hashedToken = getStoredToken(asPath)
+
   const clipboard = useClipboard()
   const [menuOpen, setMenuOpen] = useState(false)
 
@@ -74,7 +77,7 @@ const DownloadButtonGroup = () => {
       <CustomEmbedLinkMenu menuOpen={menuOpen} setMenuOpen={setMenuOpen} path={asPath} />
       <div className="flex flex-wrap justify-center gap-2">
         <DownloadButton
-          onClickCallback={() => window.open(`/api/raw?path=${asPath}`)}
+          onClickCallback={() => window.open(`/api/raw?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`)}
           btnColor="blue"
           btnText={t('Download')}
           btnIcon="file-download"
@@ -89,7 +92,9 @@ const DownloadButtonGroup = () => {
       /> */}
         <DownloadButton
           onClickCallback={() => {
-            clipboard.copy(`${getBaseUrl()}/api/raw?path=${getReadablePath(asPath)}`)
+            clipboard.copy(
+              `${getBaseUrl()}/api/raw?path=${getReadablePath(asPath)}${hashedToken ? `&odpt=${hashedToken}` : ''}`
+            )
             toast.success(t('Copied direct link to clipboard.'))
           }}
           btnColor="pink"

--- a/components/DownloadBtnGtoup.tsx
+++ b/components/DownloadBtnGtoup.tsx
@@ -10,8 +10,8 @@ import { useRouter } from 'next/router'
 
 import { getBaseUrl } from '../utils/getBaseUrl'
 import { getReadablePath } from '../utils/getReadablePath'
-import CustomEmbedLinkMenu from './CustomEmbedLinkMenu'
 import { getStoredToken } from '../utils/protectedRouteHandler'
+import CustomEmbedLinkMenu from './CustomEmbedLinkMenu'
 
 const btnStyleMap = (btnColor?: string) => {
   const colorMap = {
@@ -84,12 +84,12 @@ const DownloadButtonGroup = () => {
           btnTitle={t('Download the file directly through OneDrive')}
         />
         {/* <DownloadButton
-        onClickCallback={() => window.open(`/api/proxy?url=${encodeURIComponent(downloadUrl)}`)}
-        btnColor="teal"
-        btnText={t('Proxy download')}
-        btnIcon="download"
-        btnTitle={t('Download the file with the stream proxied through Vercel Serverless')}
-      /> */}
+          onClickCallback={() => window.open(`/api/proxy?url=${encodeURIComponent(downloadUrl)}`)}
+          btnColor="teal"
+          btnText={t('Proxy download')}
+          btnIcon="download"
+          btnTitle={t('Download the file with the stream proxied through Vercel Serverless')}
+        /> */}
         <DownloadButton
           onClickCallback={() => {
             clipboard.copy(

--- a/components/DownloadBtnGtoup.tsx
+++ b/components/DownloadBtnGtoup.tsx
@@ -62,7 +62,7 @@ export const DownloadButton = ({
   )
 }
 
-const DownloadButtonGroup: React.FC<{ downloadUrl: string }> = ({ downloadUrl }) => {
+const DownloadButtonGroup = () => {
   const { asPath } = useRouter()
   const clipboard = useClipboard()
   const [menuOpen, setMenuOpen] = useState(false)
@@ -74,7 +74,7 @@ const DownloadButtonGroup: React.FC<{ downloadUrl: string }> = ({ downloadUrl })
       <CustomEmbedLinkMenu menuOpen={menuOpen} setMenuOpen={setMenuOpen} path={asPath} />
       <div className="flex flex-wrap justify-center gap-2">
         <DownloadButton
-          onClickCallback={() => window.open(downloadUrl)}
+          onClickCallback={() => window.open(`/api/raw?path=${asPath}`)}
           btnColor="blue"
           btnText={t('Download')}
           btnIcon="file-download"
@@ -89,7 +89,7 @@ const DownloadButtonGroup: React.FC<{ downloadUrl: string }> = ({ downloadUrl })
       /> */}
         <DownloadButton
           onClickCallback={() => {
-            clipboard.copy(`${getBaseUrl()}/api?path=${getReadablePath(asPath)}&raw=true`)
+            clipboard.copy(`${getBaseUrl()}/api/raw?path=${getReadablePath(asPath)}`)
             toast.success(t('Copied direct link to clipboard.'))
           }}
           btnColor="pink"

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -237,7 +237,7 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
       const folder = folderName ? decodeURIComponent(folderName) : undefined
       const files = getFiles()
         .filter(c => selected[c.id])
-        .map(c => ({ name: c.name, url: `/api/raw?path=${path}` }))
+        .map(c => ({ name: c.name, url: `/api/raw/?path=${path}` }))
 
       if (files.length == 1) {
         const el = document.createElement('a')
@@ -280,7 +280,7 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
           }
           yield {
             name: c?.name,
-            url: `/api/raw?path=${p}`,
+            url: `/api/raw/?path=${p}`,
             path: p,
             isFolder,
           }

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -134,9 +134,9 @@ export const Checkbox: FC<{
   )
 }
 
-export const Downloading: FC<{ title: string }> = ({ title }) => {
+export const Downloading: FC<{ title: string; style: string }> = ({ title, style }) => {
   return (
-    <span title={title} className="rounded p-2" role="status">
+    <span title={title} className={`${style} rounded`} role="status">
       <LoadingIcon
         // Use fontawesome far theme via class `svg-inline--fa` to get style `vertical-align` only
         // for consistent icon alignment, as class `align-*` cannot satisfy it
@@ -237,7 +237,7 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
       const folder = folderName ? decodeURIComponent(folderName) : undefined
       const files = getFiles()
         .filter(c => selected[c.id])
-        .map(c => ({ name: c.name, url: c['@microsoft.graph.downloadUrl'] }))
+        .map(c => ({ name: c.name, url: `/api/raw?path=${path}` }))
 
       if (files.length == 1) {
         const el = document.createElement('a')
@@ -280,7 +280,7 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
           }
           yield {
             name: c?.name,
-            url: c ? c['@microsoft.graph.downloadUrl'] : undefined,
+            url: `/api/raw?path=${p}`,
             path: p,
             isFolder,
           }

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -1,9 +1,9 @@
+import type { OdFileObject, OdFolderChildren, OdFolderObject } from '../types'
+import { ParsedUrlQuery } from 'querystring'
+import { FC, MouseEventHandler, SetStateAction, useEffect, useRef, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import toast, { Toaster } from 'react-hot-toast'
 import emojiRegex from 'emoji-regex'
-
-import { ParsedUrlQuery } from 'querystring'
-import { FC, MouseEventHandler, SetStateAction, useEffect, useRef, useState } from 'react'
 
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
@@ -13,6 +13,7 @@ import useLocalStorage from '../utils/useLocalStorage'
 import { getPreviewType, preview } from '../utils/getPreviewType'
 import { useProtectedSWRInfinite } from '../utils/fetchWithSWR'
 import { getExtension, getFileIcon } from '../utils/getFileIcon'
+import { getStoredToken } from '../utils/protectedRouteHandler'
 import {
   DownloadingToast,
   downloadMultipleFiles,
@@ -36,10 +37,8 @@ import ImagePreview from './previews/ImagePreview'
 import DefaultPreview from './previews/DefaultPreview'
 import { PreviewContainer } from './previews/Containers'
 
-import type { OdFileObject, OdFolderChildren, OdFolderObject } from '../types'
 import FolderListLayout from './FolderListLayout'
 import FolderGridLayout from './FolderGridLayout'
-import { getStoredToken } from '../utils/protectedRouteHandler'
 
 // Disabling SSR for some previews
 const EPUBPreview = dynamic(() => import('./previews/EPUBPreview'), {
@@ -239,7 +238,10 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
       const folder = folderName ? decodeURIComponent(folderName) : undefined
       const files = getFiles()
         .filter(c => selected[c.id])
-        .map(c => ({ name: c.name, url: `/api/raw/?path=${path}${hashedToken ? `&odpt=${hashedToken}` : ''}` }))
+        .map(c => ({
+          name: c.name,
+          url: `/api/raw/?path=${path}/${c.name}${hashedToken ? `&odpt=${hashedToken}` : ''}`,
+        }))
 
       if (files.length == 1) {
         const el = document.createElement('a')

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -39,6 +39,7 @@ import { PreviewContainer } from './previews/Containers'
 import type { OdFileObject, OdFolderChildren, OdFolderObject } from '../types'
 import FolderListLayout from './FolderListLayout'
 import FolderGridLayout from './FolderGridLayout'
+import { getStoredToken } from '../utils/protectedRouteHandler'
 
 // Disabling SSR for some previews
 const EPUBPreview = dynamic(() => import('./previews/EPUBPreview'), {
@@ -155,6 +156,7 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
   }>({})
 
   const router = useRouter()
+  const hashedToken = getStoredToken(router.asPath)
   const [layout, _] = useLocalStorage('preferredLayout', layouts[0])
 
   const { t } = useTranslation()
@@ -237,7 +239,7 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
       const folder = folderName ? decodeURIComponent(folderName) : undefined
       const files = getFiles()
         .filter(c => selected[c.id])
-        .map(c => ({ name: c.name, url: `/api/raw/?path=${path}` }))
+        .map(c => ({ name: c.name, url: `/api/raw/?path=${path}${hashedToken ? `&odpt=${hashedToken}` : ''}` }))
 
       if (files.length == 1) {
         const el = document.createElement('a')
@@ -280,7 +282,7 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
           }
           yield {
             name: c?.name,
-            url: `/api/raw/?path=${p}`,
+            url: `/api/raw/?path=${p}${hashedToken ? `&odpt=${hashedToken}` : ''}`,
             path: p,
             isFolder,
           }

--- a/components/FileListing.tsx
+++ b/components/FileListing.tsx
@@ -282,9 +282,10 @@ const FileListing: FC<{ query?: ParsedUrlQuery }> = ({ query }) => {
             )
             continue
           }
+          const hashedTokenForPath = getStoredToken(p)
           yield {
             name: c?.name,
-            url: `/api/raw/?path=${p}${hashedToken ? `&odpt=${hashedToken}` : ''}`,
+            url: `/api/raw/?path=${p}${hashedTokenForPath ? `&odpt=${hashedTokenForPath}` : ''}`,
             path: p,
             isFolder,
           }

--- a/components/FolderGridLayout.tsx
+++ b/components/FolderGridLayout.tsx
@@ -10,10 +10,13 @@ import { getBaseUrl } from '../utils/getBaseUrl'
 import { formatModifiedDateTime } from '../utils/fileDetails'
 import { getReadablePath } from '../utils/getReadablePath'
 import { Checkbox, ChildIcon, ChildName, Downloading } from './FileListing'
+import { getStoredToken } from '../utils/protectedRouteHandler'
 
 const GridItem = ({ c, path }: { c: OdFolderChildren; path: string }) => {
   // We use the generated medium thumbnail for rendering preview images (excluding folders)
-  const thumbnailUrl = 'folder' in c ? null : `/api/thumbnail?path=${path}&size=medium`
+  const hashedToken = getStoredToken(path)
+  const thumbnailUrl =
+    'folder' in c ? null : `/api/thumbnail?path=${path}&size=medium${hashedToken ? `&odpt=${hashedToken}` : ''}`
 
   // Some thumbnails are broken, so we check for onerror event in the image component
   const [brokenThumbnail, setBrokenThumbnail] = useState(false)

--- a/components/FolderGridLayout.tsx
+++ b/components/FolderGridLayout.tsx
@@ -16,7 +16,7 @@ const GridItem = ({ c, path }: { c: OdFolderChildren; path: string }) => {
   // We use the generated medium thumbnail for rendering preview images (excluding folders)
   const hashedToken = getStoredToken(path)
   const thumbnailUrl =
-    'folder' in c ? null : `/api/thumbnail?path=${path}&size=medium${hashedToken ? `&odpt=${hashedToken}` : ''}`
+    'folder' in c ? null : `/api/thumbnail/?path=${path}&size=medium${hashedToken ? `&odpt=${hashedToken}` : ''}`
 
   // Some thumbnails are broken, so we check for onerror event in the image component
   const [brokenThumbnail, setBrokenThumbnail] = useState(false)
@@ -138,7 +138,7 @@ const FolderGridLayout = ({
                     title={t('Copy raw file permalink')}
                     className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
                     onClick={() => {
-                      clipboard.copy(`${getBaseUrl()}/api/raw?path=${getReadablePath(getItemPath(c.name))}`)
+                      clipboard.copy(`${getBaseUrl()}/api/raw/?path=${getReadablePath(getItemPath(c.name))}`)
                       toast.success(t('Copied raw file permalink.'))
                     }}
                   >
@@ -147,7 +147,7 @@ const FolderGridLayout = ({
                   <a
                     title={t('Download file')}
                     className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
-                    href={`${getBaseUrl()}/api/raw?path=${getReadablePath(getItemPath(c.name))}`}
+                    href={`${getBaseUrl()}/api/raw/?path=${getReadablePath(getItemPath(c.name))}`}
                   >
                     <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
                   </a>

--- a/components/FolderGridLayout.tsx
+++ b/components/FolderGridLayout.tsx
@@ -69,6 +69,7 @@ const FolderGridLayout = ({
   toast,
 }) => {
   const clipboard = useClipboard()
+  const hashedToken = getStoredToken(path)
 
   const { t } = useTranslation()
 
@@ -138,7 +139,11 @@ const FolderGridLayout = ({
                     title={t('Copy raw file permalink')}
                     className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
                     onClick={() => {
-                      clipboard.copy(`${getBaseUrl()}/api/raw/?path=${getReadablePath(getItemPath(c.name))}`)
+                      clipboard.copy(
+                        `${getBaseUrl()}/api/raw/?path=${getReadablePath(getItemPath(c.name))}${
+                          hashedToken ? `&odpt=${hashedToken}` : ''
+                        }`
+                      )
                       toast.success(t('Copied raw file permalink.'))
                     }}
                   >
@@ -147,7 +152,9 @@ const FolderGridLayout = ({
                   <a
                     title={t('Download file')}
                     className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
-                    href={`${getBaseUrl()}/api/raw/?path=${getReadablePath(getItemPath(c.name))}`}
+                    href={`${getBaseUrl()}/api/raw/?path=${getReadablePath(getItemPath(c.name))}${
+                      hashedToken ? `&odpt=${hashedToken}` : ''
+                    }`}
                   >
                     <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
                   </a>

--- a/components/FolderGridLayout.tsx
+++ b/components/FolderGridLayout.tsx
@@ -84,7 +84,7 @@ const FolderGridLayout = ({
             title={t('Select all files')}
           />
           {totalGenerating ? (
-            <Downloading title={t('Downloading selected files, refresh page to cancel')} />
+            <Downloading title={t('Downloading selected files, refresh page to cancel')} style="p-1.5" />
           ) : (
             <button
               title={t('Download selected files')}
@@ -118,7 +118,7 @@ const FolderGridLayout = ({
                     <FontAwesomeIcon icon={['far', 'copy']} />
                   </span>
                   {folderGenerating[c.id] ? (
-                    <Downloading title={t('Downloading folder, refresh page to cancel')} />
+                    <Downloading title={t('Downloading folder, refresh page to cancel')} style="px-1.5 py-1" />
                   ) : (
                     <span
                       title={t('Download folder')}
@@ -135,7 +135,7 @@ const FolderGridLayout = ({
                     title={t('Copy raw file permalink')}
                     className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
                     onClick={() => {
-                      clipboard.copy(`${getBaseUrl()}/api?path=${getReadablePath(getItemPath(c.name))}&raw=true`)
+                      clipboard.copy(`${getBaseUrl()}/api/raw?path=${getReadablePath(getItemPath(c.name))}`)
                       toast.success(t('Copied raw file permalink.'))
                     }}
                   >
@@ -144,7 +144,7 @@ const FolderGridLayout = ({
                   <a
                     title={t('Download file')}
                     className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
-                    href={c['@microsoft.graph.downloadUrl']}
+                    href={`${getBaseUrl()}/api/raw?path=${getReadablePath(getItemPath(c.name))}`}
                   >
                     <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
                   </a>

--- a/components/FolderListLayout.tsx
+++ b/components/FolderListLayout.tsx
@@ -136,7 +136,7 @@ const FolderListLayout = ({
                 title={t('Copy raw file permalink')}
                 className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
                 onClick={() => {
-                  clipboard.copy(`${getBaseUrl()}/api/raw?path=${getReadablePath(getItemPath(c.name))}`)
+                  clipboard.copy(`${getBaseUrl()}/api/raw/?path=${getReadablePath(getItemPath(c.name))}`)
                   toast.success(t('Copied raw file permalink.'))
                 }}
               >
@@ -145,7 +145,7 @@ const FolderListLayout = ({
               <a
                 title={t('Download file')}
                 className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
-                href={`/api/raw?path=${getItemPath(c.name)}`}
+                href={`/api/raw/?path=${getItemPath(c.name)}`}
               >
                 <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
               </a>

--- a/components/FolderListLayout.tsx
+++ b/components/FolderListLayout.tsx
@@ -48,6 +48,9 @@ const FolderListLayout = ({
 
   const { t } = useTranslation()
 
+  // Get item path from item name
+  const getItemPath = (name: string) => `${path === '/' ? '' : path}/${encodeURIComponent(name)}`
+
   return (
     <div className="rounded bg-white dark:bg-gray-900 dark:text-gray-100">
       <div className="grid grid-cols-12 items-center space-x-2 border-b border-gray-900/10 px-3 dark:border-gray-500/30">
@@ -72,7 +75,7 @@ const FolderListLayout = ({
               title={t('Select files')}
             />
             {totalGenerating ? (
-              <Downloading title={t('Downloading selected files, refresh page to cancel')} />
+              <Downloading title={t('Downloading selected files, refresh page to cancel')} style="p-1.5" />
             ) : (
               <button
                 title={t('Download selected files')}
@@ -113,7 +116,7 @@ const FolderListLayout = ({
                 <FontAwesomeIcon icon={['far', 'copy']} />
               </span>
               {folderGenerating[c.id] ? (
-                <Downloading title={t('Downloading folder, refresh page to cancel')} />
+                <Downloading title={t('Downloading folder, refresh page to cancel')} style="px-1.5 py-1" />
               ) : (
                 <span
                   title={t('Download folder')}
@@ -133,11 +136,7 @@ const FolderListLayout = ({
                 title={t('Copy raw file permalink')}
                 className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
                 onClick={() => {
-                  clipboard.copy(
-                    `${getBaseUrl()}/api?path=${getReadablePath(
-                      `${path === '/' ? '' : path}/${encodeURIComponent(c.name)}`
-                    )}&raw=true`
-                  )
+                  clipboard.copy(`${getBaseUrl()}/api/raw?path=${getReadablePath(getItemPath(c.name))}`)
                   toast.success(t('Copied raw file permalink.'))
                 }}
               >
@@ -146,7 +145,7 @@ const FolderListLayout = ({
               <a
                 title={t('Download file')}
                 className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
-                href={c['@microsoft.graph.downloadUrl']}
+                href={`/api/raw?path=${getItemPath(c.name)}`}
               >
                 <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
               </a>

--- a/components/FolderListLayout.tsx
+++ b/components/FolderListLayout.tsx
@@ -11,6 +11,7 @@ import { humanFileSize, formatModifiedDateTime } from '../utils/fileDetails'
 import { getReadablePath } from '../utils/getReadablePath'
 
 import { Downloading, Checkbox, ChildIcon, ChildName } from './FileListing'
+import { getStoredToken } from '../utils/protectedRouteHandler'
 
 const FileListItem: FC<{ fileContent: OdFolderChildren }> = ({ fileContent: c }) => {
   return (
@@ -45,6 +46,7 @@ const FolderListLayout = ({
   toast,
 }) => {
   const clipboard = useClipboard()
+  const hashedToken = getStoredToken(path)
 
   const { t } = useTranslation()
 
@@ -136,7 +138,11 @@ const FolderListLayout = ({
                 title={t('Copy raw file permalink')}
                 className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
                 onClick={() => {
-                  clipboard.copy(`${getBaseUrl()}/api/raw/?path=${getReadablePath(getItemPath(c.name))}`)
+                  clipboard.copy(
+                    `${getBaseUrl()}/api/raw/?path=${getReadablePath(getItemPath(c.name))}${
+                      hashedToken ? `&odpt=${hashedToken}` : ''
+                    }`
+                  )
                   toast.success(t('Copied raw file permalink.'))
                 }}
               >
@@ -145,7 +151,7 @@ const FolderListLayout = ({
               <a
                 title={t('Download file')}
                 className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
-                href={`/api/raw/?path=${getItemPath(c.name)}`}
+                href={`/api/raw/?path=${getItemPath(c.name)}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
               >
                 <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
               </a>

--- a/components/MultiFileDownloader.tsx
+++ b/components/MultiFileDownloader.tsx
@@ -189,7 +189,7 @@ export async function* traverseFolder(path: string): AsyncGenerator<TraverseItem
       i,
       path,
       data: await fetcher(
-        next ? `/api?path=${path}&next=${next}` : `/api?path=${path}`,
+        next ? `/api/?path=${path}&next=${next}` : `/api?path=${path}`,
         hashedToken ?? undefined
       ).catch(error => ({ i, path, error })),
     }

--- a/components/SearchModal.tsx
+++ b/components/SearchModal.tsx
@@ -45,7 +45,7 @@ function mapAbsolutePath(path: string): string {
 function useDriveItemSearch() {
   const [query, setQuery] = useState('')
   const searchDriveItem = async (q: string) => {
-    const { data } = await axios.get<OdSearchResult>(`/api/search?q=${q}`)
+    const { data } = await axios.get<OdSearchResult>(`/api/search/?q=${q}`)
 
     // Map parentReference to the absolute path of the search result
     data.map(item => {
@@ -111,7 +111,7 @@ function SearchResultItemTemplate({
 }
 
 function SearchResultItemLoadRemote({ result }: { result: OdSearchResult[number] }) {
-  const { data, error }: SWRResponse<OdDriveItem, string> = useSWR(`/api/item?id=${result.id}`, fetcher)
+  const { data, error }: SWRResponse<OdDriveItem, string> = useSWR(`/api/item/?id=${result.id}`, fetcher)
 
   const { t } = useTranslation()
 

--- a/components/previews/AudioPreview.tsx
+++ b/components/previews/AudioPreview.tsx
@@ -28,7 +28,7 @@ const AudioPreview: FC<{ file: OdFileObject }> = ({ file }) => {
   const [playerStatus, setPlayerStatus] = useState(PlayerState.Loading)
 
   // Render audio thumbnail, and also check for broken thumbnails
-  const thumbnail = `/api/thumbnail?path=${asPath}&size=medium${hashedToken ? `&odpt=${hashedToken}` : ''}`
+  const thumbnail = `/api/thumbnail/?path=${asPath}&size=medium${hashedToken ? `&odpt=${hashedToken}` : ''}`
   const [brokenThumbnail, setBrokenThumbnail] = useState(false)
 
   useEffect(() => {
@@ -94,7 +94,7 @@ const AudioPreview: FC<{ file: OdFileObject }> = ({ file }) => {
 
             <ReactAudioPlayer
               className="h-11 w-full"
-              src={`/api/raw?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
+              src={`/api/raw/?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
               ref={rapRef}
               controls
               preload="auto"

--- a/components/previews/AudioPreview.tsx
+++ b/components/previews/AudioPreview.tsx
@@ -90,19 +90,13 @@ const AudioPreview: FC<{ file: OdFileObject }> = ({ file }) => {
               </div>
             </div>
 
-            <ReactAudioPlayer
-              className="h-11 w-full"
-              src={file['@microsoft.graph.downloadUrl']}
-              ref={rapRef}
-              controls
-              preload="auto"
-            />
+            <ReactAudioPlayer className="h-11 w-full" src={`/api/raw?path=${asPath}`} ref={rapRef} controls preload="auto" />
           </div>
         </div>
       </PreviewContainer>
 
       <DownloadBtnContainer>
-        <DownloadButtonGroup downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadButtonGroup />
       </DownloadBtnContainer>
     </>
   )

--- a/components/previews/AudioPreview.tsx
+++ b/components/previews/AudioPreview.tsx
@@ -28,7 +28,7 @@ const AudioPreview: FC<{ file: OdFileObject }> = ({ file }) => {
   const [playerStatus, setPlayerStatus] = useState(PlayerState.Loading)
 
   // Render audio thumbnail, and also check for broken thumbnails
-  const thumbnail = `/api/thumbnail?path=${asPath}&size=medium`
+  const thumbnail = `/api/thumbnail?path=${asPath}&size=medium${hashedToken ? `&odpt=${hashedToken}` : ''}`
   const [brokenThumbnail, setBrokenThumbnail] = useState(false)
 
   useEffect(() => {

--- a/components/previews/AudioPreview.tsx
+++ b/components/previews/AudioPreview.tsx
@@ -10,6 +10,7 @@ import DownloadButtonGroup from '../DownloadBtnGtoup'
 import { DownloadBtnContainer, PreviewContainer } from './Containers'
 import { LoadingIcon } from '../Loading'
 import { formatModifiedDateTime } from '../../utils/fileDetails'
+import { getStoredToken } from '../../utils/protectedRouteHandler'
 
 enum PlayerState {
   Loading,
@@ -21,6 +22,7 @@ enum PlayerState {
 const AudioPreview: FC<{ file: OdFileObject }> = ({ file }) => {
   const { t } = useTranslation()
   const { asPath } = useRouter()
+  const hashedToken = getStoredToken(asPath)
 
   const rapRef = useRef<ReactAudioPlayer>(null)
   const [playerStatus, setPlayerStatus] = useState(PlayerState.Loading)
@@ -90,7 +92,13 @@ const AudioPreview: FC<{ file: OdFileObject }> = ({ file }) => {
               </div>
             </div>
 
-            <ReactAudioPlayer className="h-11 w-full" src={`/api/raw?path=${asPath}`} ref={rapRef} controls preload="auto" />
+            <ReactAudioPlayer
+              className="h-11 w-full"
+              src={`/api/raw?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
+              ref={rapRef}
+              controls
+              preload="auto"
+            />
           </div>
         </div>
       </PreviewContainer>

--- a/components/previews/CodePreview.tsx
+++ b/components/previews/CodePreview.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react'
 import { useTranslation } from 'next-i18next'
 import useSystemTheme from 'react-use-system-theme'
+import { useRouter } from 'next/router'
 
 import { LightAsync as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { tomorrowNightEighties, tomorrow } from 'react-syntax-highlighter/dist/cjs/styles/hljs'
@@ -13,7 +14,8 @@ import DownloadButtonGroup from '../DownloadBtnGtoup'
 import { DownloadBtnContainer, PreviewContainer } from './Containers'
 
 const CodePreview: FC<{ file: any }> = ({ file }) => {
-  const { response: content, error, validating } = useAxiosGet(file['@microsoft.graph.downloadUrl'])
+  const { asPath } = useRouter()
+  const { response: content, error, validating } = useAxiosGet(`/api/raw?path=${asPath}`)
 
   const theme = useSystemTheme('dark')
   const { t } = useTranslation()
@@ -44,7 +46,7 @@ const CodePreview: FC<{ file: any }> = ({ file }) => {
         </SyntaxHighlighter>
       </PreviewContainer>
       <DownloadBtnContainer>
-        <DownloadButtonGroup downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadButtonGroup />
       </DownloadBtnContainer>
     </div>
   )

--- a/components/previews/CodePreview.tsx
+++ b/components/previews/CodePreview.tsx
@@ -15,7 +15,7 @@ import { DownloadBtnContainer, PreviewContainer } from './Containers'
 
 const CodePreview: FC<{ file: any }> = ({ file }) => {
   const { asPath } = useRouter()
-  const { response: content, error, validating } = useFileContent(`/api/raw?path=${asPath}`, asPath)
+  const { response: content, error, validating } = useFileContent(`/api/raw/?path=${asPath}`, asPath)
 
   const theme = useSystemTheme('dark')
   const { t } = useTranslation()

--- a/components/previews/CodePreview.tsx
+++ b/components/previews/CodePreview.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router'
 import { LightAsync as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { tomorrowNightEighties, tomorrow } from 'react-syntax-highlighter/dist/cjs/styles/hljs'
 
-import useAxiosGet from '../../utils/fetchOnMount'
+import useFileContent from '../../utils/fetchOnMount'
 import { getLanguageByFileName } from '../../utils/getPreviewType'
 import FourOhFour from '../FourOhFour'
 import Loading from '../Loading'
@@ -15,7 +15,7 @@ import { DownloadBtnContainer, PreviewContainer } from './Containers'
 
 const CodePreview: FC<{ file: any }> = ({ file }) => {
   const { asPath } = useRouter()
-  const { response: content, error, validating } = useAxiosGet(`/api/raw?path=${asPath}`)
+  const { response: content, error, validating } = useFileContent(`/api/raw?path=${asPath}`, asPath)
 
   const theme = useSystemTheme('dark')
   const { t } = useTranslation()

--- a/components/previews/DefaultPreview.tsx
+++ b/components/previews/DefaultPreview.tsx
@@ -35,7 +35,7 @@ const DefaultPreview: FC<{ file: OdFileObject }> = ({ file }) => {
 
             <div>
               <div className="py-2 text-xs font-medium uppercase opacity-80">{t('MIME type')}</div>
-              <div>{file.file?.mimeType || t('Unavailable')}</div>
+              <div>{file.file?.mimeType ?? t('Unavailable')}</div>
             </div>
 
             <div>
@@ -47,7 +47,7 @@ const DefaultPreview: FC<{ file: OdFileObject }> = ({ file }) => {
                       Quick XOR
                     </td>
                     <td className="whitespace-nowrap py-1 px-3 font-mono text-gray-500 dark:text-gray-400">
-                      {file.file.hashes?.quickXorHash || t('Unavailable')}
+                      {file.file.hashes?.quickXorHash ?? t('Unavailable')}
                     </td>
                   </tr>
                   <tr className="border-y bg-white dark:border-gray-700 dark:bg-gray-900">
@@ -55,7 +55,7 @@ const DefaultPreview: FC<{ file: OdFileObject }> = ({ file }) => {
                       SHA1
                     </td>
                     <td className="whitespace-nowrap py-1 px-3 font-mono text-gray-500 dark:text-gray-400">
-                      {file.file.hashes?.sha1Hash || t('Unavailable')}
+                      {file.file.hashes?.sha1Hash ?? t('Unavailable')}
                     </td>
                   </tr>
                   <tr className="border-y bg-white dark:border-gray-700 dark:bg-gray-900">
@@ -63,7 +63,7 @@ const DefaultPreview: FC<{ file: OdFileObject }> = ({ file }) => {
                       SHA256
                     </td>
                     <td className="whitespace-nowrap py-1 px-3 font-mono text-gray-500 dark:text-gray-400">
-                      {file.file.hashes?.sha256Hash || t('Unavailable')}
+                      {file.file.hashes?.sha256Hash ?? t('Unavailable')}
                     </td>
                   </tr>
                 </tbody>

--- a/components/previews/DefaultPreview.tsx
+++ b/components/previews/DefaultPreview.tsx
@@ -73,7 +73,7 @@ const DefaultPreview: FC<{ file: OdFileObject }> = ({ file }) => {
         </div>
       </PreviewContainer>
       <DownloadBtnContainer>
-        <DownloadButtonGroup downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadButtonGroup />
       </DownloadBtnContainer>
     </div>
   )

--- a/components/previews/EPUBPreview.tsx
+++ b/components/previews/EPUBPreview.tsx
@@ -2,6 +2,7 @@ import type { OdFileObject } from '../../types'
 
 import { FC, useEffect, useRef, useState } from 'react'
 import { ReactReader } from 'react-reader'
+import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 
 import Loading from '../Loading'
@@ -9,6 +10,7 @@ import DownloadButtonGroup from '../DownloadBtnGtoup'
 import { DownloadBtnContainer } from './Containers'
 
 const EPUBPreview: FC<{ file: OdFileObject }> = ({ file }) => {
+  const { asPath } = useRouter()
   const [epubContainerWidth, setEpubContainerWidth] = useState(400)
   const epubContainer = useRef<HTMLDivElement>(null)
 
@@ -51,7 +53,7 @@ const EPUBPreview: FC<{ file: OdFileObject }> = ({ file }) => {
             }}
           >
             <ReactReader
-              url={file['@microsoft.graph.downloadUrl']}
+              url={`/api/raw?path=${asPath}`}
               getRendition={rendition => fixEpub(rendition)}
               loadingView={<Loading loadingText={t('Loading EPUB ...')} />}
               location={location}
@@ -63,7 +65,7 @@ const EPUBPreview: FC<{ file: OdFileObject }> = ({ file }) => {
         </div>
       </div>
       <DownloadBtnContainer>
-        <DownloadButtonGroup downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadButtonGroup />
       </DownloadBtnContainer>
     </div>
   )

--- a/components/previews/EPUBPreview.tsx
+++ b/components/previews/EPUBPreview.tsx
@@ -8,9 +8,12 @@ import { useTranslation } from 'next-i18next'
 import Loading from '../Loading'
 import DownloadButtonGroup from '../DownloadBtnGtoup'
 import { DownloadBtnContainer } from './Containers'
+import { getStoredToken } from '../../utils/protectedRouteHandler'
 
 const EPUBPreview: FC<{ file: OdFileObject }> = ({ file }) => {
   const { asPath } = useRouter()
+  const hashedToken = getStoredToken(asPath)
+
   const [epubContainerWidth, setEpubContainerWidth] = useState(400)
   const epubContainer = useRef<HTMLDivElement>(null)
 
@@ -53,7 +56,7 @@ const EPUBPreview: FC<{ file: OdFileObject }> = ({ file }) => {
             }}
           >
             <ReactReader
-              url={`/api/raw?path=${asPath}`}
+              url={`/api/raw?path=${asPath}${hashedToken ? '&token=' + hashedToken : ''}`}
               getRendition={rendition => fixEpub(rendition)}
               loadingView={<Loading loadingText={t('Loading EPUB ...')} />}
               location={location}

--- a/components/previews/EPUBPreview.tsx
+++ b/components/previews/EPUBPreview.tsx
@@ -56,7 +56,7 @@ const EPUBPreview: FC<{ file: OdFileObject }> = ({ file }) => {
             }}
           >
             <ReactReader
-              url={`/api/raw?path=${asPath}${hashedToken ? '&token=' + hashedToken : ''}`}
+              url={`/api/raw/?path=${asPath}${hashedToken ? '&token=' + hashedToken : ''}`}
               getRendition={rendition => fixEpub(rendition)}
               loadingView={<Loading loadingText={t('Loading EPUB ...')} />}
               location={location}

--- a/components/previews/ImagePreview.tsx
+++ b/components/previews/ImagePreview.tsx
@@ -17,7 +17,7 @@ const ImagePreview: FC<{ file: OdFileObject }> = ({ file }) => {
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           className="mx-auto"
-          src={`/api/raw?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
+          src={`/api/raw/?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
           alt={file.name}
           width={file.image?.width}
           height={file.image?.height}

--- a/components/previews/ImagePreview.tsx
+++ b/components/previews/ImagePreview.tsx
@@ -1,25 +1,27 @@
 import type { OdFileObject } from '../../types'
 
 import { FC } from 'react'
+import { useRouter } from 'next/router'
 
 import { PreviewContainer, DownloadBtnContainer } from './Containers'
 import DownloadButtonGroup from '../DownloadBtnGtoup'
 
 const ImagePreview: FC<{ file: OdFileObject }> = ({ file }) => {
+  const { asPath } = useRouter()
   return (
     <>
       <PreviewContainer>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           className="mx-auto"
-          src={file['@microsoft.graph.downloadUrl']}
+          src={`/api/raw?path=${asPath}`}
           alt={file.name}
           width={file.image?.width}
           height={file.image?.height}
         />
       </PreviewContainer>
       <DownloadBtnContainer>
-        <DownloadButtonGroup downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadButtonGroup />
       </DownloadBtnContainer>
     </>
   )

--- a/components/previews/ImagePreview.tsx
+++ b/components/previews/ImagePreview.tsx
@@ -5,16 +5,19 @@ import { useRouter } from 'next/router'
 
 import { PreviewContainer, DownloadBtnContainer } from './Containers'
 import DownloadButtonGroup from '../DownloadBtnGtoup'
+import { getStoredToken } from '../../utils/protectedRouteHandler'
 
 const ImagePreview: FC<{ file: OdFileObject }> = ({ file }) => {
   const { asPath } = useRouter()
+  const hashedToken = getStoredToken(asPath)
+
   return (
     <>
       <PreviewContainer>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           className="mx-auto"
-          src={`/api/raw?path=${asPath}`}
+          src={`/api/raw?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
           alt={file.name}
           width={file.image?.width}
           height={file.image?.height}

--- a/components/previews/MarkdownPreview.tsx
+++ b/components/previews/MarkdownPreview.tsx
@@ -23,7 +23,7 @@ const MarkdownPreview: FC<{
   // The parent folder of the markdown file, which is also the relative image folder
   const parentPath = standalone ? path.substring(0, path.lastIndexOf('/')) : path
 
-  const { response: content, error, validating } = useFileContent(`/api/raw?path=${parentPath}/${file.name}`, path)
+  const { response: content, error, validating } = useFileContent(`/api/raw/?path=${parentPath}/${file.name}`, path)
   const { t } = useTranslation()
 
   // Check if the image is relative path instead of a absolute url
@@ -55,7 +55,7 @@ const MarkdownPreview: FC<{
         // eslint-disable-next-line @next/next/no-img-element
         <img
           alt={alt}
-          src={`/api?path=${parentPath}/${src}&raw=true`}
+          src={`/api/?path=${parentPath}/${src}&raw=true`}
           title={title}
           width={width}
           height={height}

--- a/components/previews/MarkdownPreview.tsx
+++ b/components/previews/MarkdownPreview.tsx
@@ -12,7 +12,7 @@ import 'katex/dist/katex.min.css'
 import FourOhFour from '../FourOhFour'
 import Loading from '../Loading'
 import DownloadButtonGroup from '../DownloadBtnGtoup'
-import useAxiosGet from '../../utils/fetchOnMount'
+import useFileContent from '../../utils/fetchOnMount'
 import { DownloadBtnContainer, PreviewContainer } from './Containers'
 
 const MarkdownPreview: FC<{
@@ -23,7 +23,7 @@ const MarkdownPreview: FC<{
   // The parent folder of the markdown file, which is also the relative image folder
   const parentPath = standalone ? path.substring(0, path.lastIndexOf('/')) : path
 
-  const { response: content, error, validating } = useAxiosGet(`/api/raw?path=${parentPath}/${file.name}`)
+  const { response: content, error, validating } = useFileContent(`/api/raw?path=${parentPath}/${file.name}`, path)
   const { t } = useTranslation()
 
   // Check if the image is relative path instead of a absolute url

--- a/components/previews/MarkdownPreview.tsx
+++ b/components/previews/MarkdownPreview.tsx
@@ -23,7 +23,7 @@ const MarkdownPreview: FC<{
   // The parent folder of the markdown file, which is also the relative image folder
   const parentPath = standalone ? path.substring(0, path.lastIndexOf('/')) : path
 
-  const { response: content, error, validating } = useAxiosGet(`/api/raw?path=${parentPath}%2F${file.name}`)
+  const { response: content, error, validating } = useAxiosGet(`/api/raw?path=${parentPath}/${file.name}`)
   const { t } = useTranslation()
 
   // Check if the image is relative path instead of a absolute url

--- a/components/previews/MarkdownPreview.tsx
+++ b/components/previews/MarkdownPreview.tsx
@@ -20,12 +20,12 @@ const MarkdownPreview: FC<{
   path: string
   standalone?: boolean
 }> = ({ file, path, standalone = true }) => {
-  const { response: content, error, validating } = useAxiosGet(file['@microsoft.graph.downloadUrl'])
-
-  const { t } = useTranslation()
-
   // The parent folder of the markdown file, which is also the relative image folder
   const parentPath = standalone ? path.substring(0, path.lastIndexOf('/')) : path
+
+  const { response: content, error, validating } = useAxiosGet(`/api/raw?path=${parentPath}%2F${file.name}`)
+  const { t } = useTranslation()
+
   // Check if the image is relative path instead of a absolute url
   const isUrlAbsolute = (url: string | string[]) => url.indexOf('://') > 0 || url.indexOf('//') === 0
   // Custom renderer to render images with relative path
@@ -100,7 +100,7 @@ const MarkdownPreview: FC<{
       </PreviewContainer>
       {standalone && (
         <DownloadBtnContainer>
-          <DownloadButtonGroup downloadUrl={file['@microsoft.graph.downloadUrl']} />
+          <DownloadButtonGroup />
         </DownloadBtnContainer>
       )}
     </div>

--- a/components/previews/OfficePreview.tsx
+++ b/components/previews/OfficePreview.tsx
@@ -6,9 +6,13 @@ import Preview from 'preview-office-docs'
 
 import DownloadButtonGroup from '../DownloadBtnGtoup'
 import { DownloadBtnContainer } from './Containers'
+import { getBaseUrl } from '../../utils/getBaseUrl'
+import { getStoredToken } from '../../utils/protectedRouteHandler'
 
 const OfficePreview: FC<{ file: OdFileObject }> = ({ file }) => {
   const { asPath } = useRouter()
+  const hashedToken = getStoredToken(asPath)
+
   const docContainer = useRef<HTMLDivElement>(null)
   const [docContainerWidth, setDocContainerWidth] = useState(600)
 
@@ -19,7 +23,11 @@ const OfficePreview: FC<{ file: OdFileObject }> = ({ file }) => {
   return (
     <div>
       <div className="overflow-scroll" ref={docContainer} style={{ maxHeight: '90vh' }}>
-        <Preview url={`/api/raw?path=${asPath}`} width={docContainerWidth.toString()} height="600" />
+        <Preview
+          url={`${getBaseUrl()}/api/raw?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
+          width={docContainerWidth.toString()}
+          height="600"
+        />
       </div>
       <DownloadBtnContainer>
         <DownloadButtonGroup />

--- a/components/previews/OfficePreview.tsx
+++ b/components/previews/OfficePreview.tsx
@@ -24,7 +24,7 @@ const OfficePreview: FC<{ file: OdFileObject }> = ({ file }) => {
     <div>
       <div className="overflow-scroll" ref={docContainer} style={{ maxHeight: '90vh' }}>
         <Preview
-          url={`${getBaseUrl()}/api/raw?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
+          url={`${getBaseUrl()}/api/raw/?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
           width={docContainerWidth.toString()}
           height="600"
         />

--- a/components/previews/OfficePreview.tsx
+++ b/components/previews/OfficePreview.tsx
@@ -1,5 +1,6 @@
 import type { OdFileObject } from '../../types'
 import { FC, useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/router'
 
 import Preview from 'preview-office-docs'
 
@@ -7,6 +8,7 @@ import DownloadButtonGroup from '../DownloadBtnGtoup'
 import { DownloadBtnContainer } from './Containers'
 
 const OfficePreview: FC<{ file: OdFileObject }> = ({ file }) => {
+  const { asPath } = useRouter()
   const docContainer = useRef<HTMLDivElement>(null)
   const [docContainerWidth, setDocContainerWidth] = useState(600)
 
@@ -17,14 +19,10 @@ const OfficePreview: FC<{ file: OdFileObject }> = ({ file }) => {
   return (
     <div>
       <div className="overflow-scroll" ref={docContainer} style={{ maxHeight: '90vh' }}>
-        <Preview
-          url={encodeURIComponent(file['@microsoft.graph.downloadUrl'])}
-          width={docContainerWidth.toString()}
-          height="600"
-        />
+        <Preview url={`/api/raw?path=${asPath}`} width={docContainerWidth.toString()} height="600" />
       </div>
       <DownloadBtnContainer>
-        <DownloadButtonGroup downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadButtonGroup />
       </DownloadBtnContainer>
     </div>
   )

--- a/components/previews/PDFPreview.tsx
+++ b/components/previews/PDFPreview.tsx
@@ -1,12 +1,17 @@
 import { useRouter } from 'next/router'
 import { getBaseUrl } from '../../utils/getBaseUrl'
+import { getStoredToken } from '../../utils/protectedRouteHandler'
 import DownloadButtonGroup from '../DownloadBtnGtoup'
 import { DownloadBtnContainer } from './Containers'
 
 const PDFEmbedPreview: React.FC<{ file: any }> = ({ file }) => {
   const { asPath } = useRouter()
+  const hashedToken = getStoredToken(asPath)
+
   // const url = `/api/proxy?url=${encodeURIComponent(...)}&inline=true`
-  const pdfPath = encodeURIComponent(`${getBaseUrl()}/api/raw?path=${asPath}`)
+  const pdfPath = encodeURIComponent(
+    `${getBaseUrl()}/api/raw?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`
+  )
   const url = `https://mozilla.github.io/pdf.js/web/viewer.html?file=${pdfPath}`
 
   return (

--- a/components/previews/PDFPreview.tsx
+++ b/components/previews/PDFPreview.tsx
@@ -1,11 +1,13 @@
+import { useRouter } from 'next/router'
+import { getBaseUrl } from '../../utils/getBaseUrl'
 import DownloadButtonGroup from '../DownloadBtnGtoup'
 import { DownloadBtnContainer } from './Containers'
 
 const PDFEmbedPreview: React.FC<{ file: any }> = ({ file }) => {
-  // const url = `/api/proxy?url=${encodeURIComponent(file['@microsoft.graph.downloadUrl'])}&inline=true`
-  const url = `https://mozilla.github.io/pdf.js/web/viewer.html?file=${encodeURIComponent(
-    file['@microsoft.graph.downloadUrl']
-  )}`
+  const { asPath } = useRouter()
+  // const url = `/api/proxy?url=${encodeURIComponent(...)}&inline=true`
+  const pdfPath = encodeURIComponent(`${getBaseUrl()}/api/raw?path=${asPath}`)
+  const url = `https://mozilla.github.io/pdf.js/web/viewer.html?file=${pdfPath}`
 
   return (
     <div>
@@ -13,7 +15,7 @@ const PDFEmbedPreview: React.FC<{ file: any }> = ({ file }) => {
         <iframe src={url} frameBorder="0" width="100%" height="100%"></iframe>
       </div>
       <DownloadBtnContainer>
-        <DownloadButtonGroup downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadButtonGroup />
       </DownloadBtnContainer>
     </div>
   )

--- a/components/previews/PDFPreview.tsx
+++ b/components/previews/PDFPreview.tsx
@@ -10,7 +10,7 @@ const PDFEmbedPreview: React.FC<{ file: any }> = ({ file }) => {
 
   // const url = `/api/proxy?url=${encodeURIComponent(...)}&inline=true`
   const pdfPath = encodeURIComponent(
-    `${getBaseUrl()}/api/raw?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`
+    `${getBaseUrl()}/api/raw/?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`
   )
   const url = `https://mozilla.github.io/pdf.js/web/viewer.html?file=${pdfPath}`
 

--- a/components/previews/TextPreview.tsx
+++ b/components/previews/TextPreview.tsx
@@ -11,7 +11,7 @@ const TextPreview = ({ file }) => {
   const { asPath } = useRouter()
   const { t } = useTranslation()
 
-  const { response: content, error, validating } = useFileContent(`/api/raw?path=${asPath}`, asPath)
+  const { response: content, error, validating } = useFileContent(`/api/raw/?path=${asPath}`, asPath)
   if (error) {
     return (
       <PreviewContainer>

--- a/components/previews/TextPreview.tsx
+++ b/components/previews/TextPreview.tsx
@@ -4,14 +4,14 @@ import { useTranslation } from 'next-i18next'
 import FourOhFour from '../FourOhFour'
 import Loading from '../Loading'
 import DownloadButtonGroup from '../DownloadBtnGtoup'
-import useAxiosGet from '../../utils/fetchOnMount'
+import useFileContent from '../../utils/fetchOnMount'
 import { DownloadBtnContainer, PreviewContainer } from './Containers'
 
 const TextPreview = ({ file }) => {
   const { asPath } = useRouter()
   const { t } = useTranslation()
 
-  const { response: content, error, validating } = useAxiosGet(`/api/raw?path=${asPath}`)
+  const { response: content, error, validating } = useFileContent(`/api/raw?path=${asPath}`, asPath)
   if (error) {
     return (
       <PreviewContainer>

--- a/components/previews/TextPreview.tsx
+++ b/components/previews/TextPreview.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 
 import FourOhFour from '../FourOhFour'
@@ -7,9 +8,10 @@ import useAxiosGet from '../../utils/fetchOnMount'
 import { DownloadBtnContainer, PreviewContainer } from './Containers'
 
 const TextPreview = ({ file }) => {
+  const { asPath } = useRouter()
   const { t } = useTranslation()
 
-  const { response: content, error, validating } = useAxiosGet(file['@microsoft.graph.downloadUrl'])
+  const { response: content, error, validating } = useAxiosGet(`/api/raw?path=${asPath}`)
   if (error) {
     return (
       <PreviewContainer>
@@ -40,7 +42,7 @@ const TextPreview = ({ file }) => {
         <pre className="overflow-x-scroll p-0 text-sm md:p-3">{content}</pre>
       </PreviewContainer>
       <DownloadBtnContainer>
-        <DownloadButtonGroup downloadUrl={file['@microsoft.graph.downloadUrl']} />
+        <DownloadButtonGroup />
       </DownloadBtnContainer>
     </div>
   )

--- a/components/previews/URLPreview.tsx
+++ b/components/previews/URLPreview.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 
 import FourOhFour from '../FourOhFour'
@@ -14,9 +15,10 @@ const parseDotUrl = (content: string): string | undefined => {
 }
 
 const TextPreview = ({ file }) => {
+  const { asPath } = useRouter()
   const { t } = useTranslation()
 
-  const { response: content, error, validating } = useAxiosGet(file['@microsoft.graph.downloadUrl'])
+  const { response: content, error, validating } = useAxiosGet(`/api/raw?path=${asPath}`)
   if (error) {
     return (
       <PreviewContainer>

--- a/components/previews/URLPreview.tsx
+++ b/components/previews/URLPreview.tsx
@@ -51,11 +51,11 @@ const TextPreview = ({ file }) => {
       <DownloadBtnContainer>
         <div className="flex justify-center">
           <DownloadButton
-            onClickCallback={() => window.open(parseDotUrl(content) || '')}
+            onClickCallback={() => window.open(parseDotUrl(content) ?? '')}
             btnColor="blue"
             btnText={t('Open URL')}
             btnIcon="external-link-alt"
-            btnTitle={t('Open URL{{url}}', { url: ' ' + parseDotUrl(content) || '' })}
+            btnTitle={t('Open URL{{url}}', { url: ' ' + parseDotUrl(content) ?? '' })}
           />
         </div>
       </DownloadBtnContainer>

--- a/components/previews/URLPreview.tsx
+++ b/components/previews/URLPreview.tsx
@@ -18,7 +18,7 @@ const TextPreview = ({ file }) => {
   const { asPath } = useRouter()
   const { t } = useTranslation()
 
-  const { response: content, error, validating } = useFileContent(`/api/raw?path=${asPath}`, asPath)
+  const { response: content, error, validating } = useFileContent(`/api/raw/?path=${asPath}`, asPath)
   if (error) {
     return (
       <PreviewContainer>

--- a/components/previews/URLPreview.tsx
+++ b/components/previews/URLPreview.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'next-i18next'
 import FourOhFour from '../FourOhFour'
 import Loading from '../Loading'
 import { DownloadButton } from '../DownloadBtnGtoup'
-import useAxiosGet from '../../utils/fetchOnMount'
+import useFileContent from '../../utils/fetchOnMount'
 import { DownloadBtnContainer, PreviewContainer } from './Containers'
 
 const parseDotUrl = (content: string): string | undefined => {
@@ -18,7 +18,7 @@ const TextPreview = ({ file }) => {
   const { asPath } = useRouter()
   const { t } = useTranslation()
 
-  const { response: content, error, validating } = useAxiosGet(`/api/raw?path=${asPath}`)
+  const { response: content, error, validating } = useFileContent(`/api/raw?path=${asPath}`, asPath)
   if (error) {
     return (
       <PreviewContainer>

--- a/components/previews/VideoPreview.tsx
+++ b/components/previews/VideoPreview.tsx
@@ -26,14 +26,14 @@ const VideoPreview: React.FC<{ file: OdFileObject }> = ({ file }) => {
   const { t } = useTranslation()
 
   // OneDrive generates thumbnails for its video files, we pick the thumbnail with the highest resolution
-  const thumbnail = `/api/thumbnail?path=${asPath}&size=large${hashedToken ? `&odpt=${hashedToken}` : ''}`
+  const thumbnail = `/api/thumbnail/?path=${asPath}&size=large${hashedToken ? `&odpt=${hashedToken}` : ''}`
 
   // We assume subtitle files are beside the video with the same name, only webvtt '.vtt' files are supported
   const vtt = `${asPath.substring(0, asPath.lastIndexOf('.'))}.vtt`
-  const subtitle = `/api/raw?path=${vtt}${hashedToken ? `&odpt=${hashedToken}` : ''}`
+  const subtitle = `/api/raw/?path=${vtt}${hashedToken ? `&odpt=${hashedToken}` : ''}`
 
   // We also format the raw video file for the in-browser player as well as all other players
-  const videoUrl = `/api/raw?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`
+  const videoUrl = `/api/raw/?path=${asPath}${hashedToken ? `&odpt=${hashedToken}` : ''}`
 
   const isFlv = getExtension(file.name) === 'flv'
   const {
@@ -100,7 +100,7 @@ const VideoPreview: React.FC<{ file: OdFileObject }> = ({ file }) => {
           <DownloadButton
             onClickCallback={() => {
               clipboard.copy(
-                `${getBaseUrl()}/api/raw?path=${getReadablePath(asPath)}${hashedToken ? `&odpt=${hashedToken}` : ''}`
+                `${getBaseUrl()}/api/raw/?path=${getReadablePath(asPath)}${hashedToken ? `&odpt=${hashedToken}` : ''}`
               )
               toast.success(t('Copied direct link to clipboard.'))
             }}

--- a/components/previews/VideoPreview.tsx
+++ b/components/previews/VideoPreview.tsx
@@ -26,7 +26,7 @@ const VideoPreview: React.FC<{ file: OdFileObject }> = ({ file }) => {
   const { t } = useTranslation()
 
   // OneDrive generates thumbnails for its video files, we pick the thumbnail with the highest resolution
-  const thumbnail = `/api/thumbnail?path=${asPath}&size=large`
+  const thumbnail = `/api/thumbnail?path=${asPath}&size=large${hashedToken ? `&odpt=${hashedToken}` : ''}`
 
   // We assume subtitle files are beside the video with the same name, only webvtt '.vtt' files are supported
   const vtt = `${asPath.substring(0, asPath.lastIndexOf('.'))}.vtt`

--- a/components/previews/VideoPreview.tsx
+++ b/components/previews/VideoPreview.tsx
@@ -48,7 +48,7 @@ const VideoPreview: React.FC<{ file: OdFileObject }> = ({ file }) => {
 
   return (
     <>
-      <CustomEmbedLinkMenu path={getReadablePath(asPath)} menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
+      <CustomEmbedLinkMenu path={asPath} menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
       <PreviewContainer>
         {error ? (
           <FourOhFour errorMsg={error.message} />

--- a/components/previews/VideoPreview.tsx
+++ b/components/previews/VideoPreview.tsx
@@ -55,7 +55,7 @@ const VideoPreview: React.FC<{ file: OdFileObject }> = ({ file }) => {
               volume: 1.0,
               lang: 'en',
               video: {
-                url: file['@microsoft.graph.downloadUrl'],
+                url: `/api/raw?path=${asPath}`,
                 pic: thumbnail,
                 type: isFlv ? 'customFlv' : 'auto',
                 customType: {
@@ -78,14 +78,14 @@ const VideoPreview: React.FC<{ file: OdFileObject }> = ({ file }) => {
       <DownloadBtnContainer>
         <div className="flex flex-wrap justify-center gap-2">
           <DownloadButton
-            onClickCallback={() => window.open(file['@microsoft.graph.downloadUrl'])}
+            onClickCallback={() => window.open(`/api/raw?path=${asPath}`)}
             btnColor="blue"
             btnText={t('Download')}
             btnIcon="file-download"
           />
           {/* <DownloadButton
             onClickCallback={() =>
-              window.open(`/api/proxy?url=${encodeURIComponent(file['@microsoft.graph.downloadUrl'])}`)
+              window.open(`/api/proxy?url=${encodeURIComponent(...)}`)
             }
             btnColor="teal"
             btnText={t('Proxy download')}
@@ -93,7 +93,7 @@ const VideoPreview: React.FC<{ file: OdFileObject }> = ({ file }) => {
           /> */}
           <DownloadButton
             onClickCallback={() => {
-              clipboard.copy(`${getBaseUrl()}/api?path=${getReadablePath(asPath)}&raw=true`)
+              clipboard.copy(`${getBaseUrl()}/api/raw?path=${getReadablePath(asPath)}`)
               toast.success(t('Copied direct link to clipboard.'))
             }}
             btnColor="pink"
@@ -108,17 +108,17 @@ const VideoPreview: React.FC<{ file: OdFileObject }> = ({ file }) => {
           />
 
           <DownloadButton
-            onClickCallback={() => window.open(`iina://weblink?url=${file['@microsoft.graph.downloadUrl']}`)}
+            onClickCallback={() => window.open(`iina://weblink?url=${getBaseUrl()}/api/raw?path=${asPath}`)}
             btnText="IINA"
             btnImage="/players/iina.png"
           />
           <DownloadButton
-            onClickCallback={() => window.open(`vlc://${file['@microsoft.graph.downloadUrl']}`)}
+            onClickCallback={() => window.open(`vlc://${getBaseUrl()}/api/raw?path=${asPath}`)}
             btnText="VLC"
             btnImage="/players/vlc.png"
           />
           <DownloadButton
-            onClickCallback={() => window.open(`potplayer://${file['@microsoft.graph.downloadUrl']}`)}
+            onClickCallback={() => window.open(`potplayer://${getBaseUrl()}/api/raw?path=${asPath}`)}
             btnText="PotPlayer"
             btnImage="/players/potplayer.png"
           />

--- a/config/api.config.js
+++ b/config/api.config.js
@@ -34,5 +34,5 @@ module.exports = {
   // - s-maxage=0: cache is fresh for 0 seconds on the edge, after which it becomes stale
   // - stale-while-revalidate: allow serving stale content while revalidating on the edge
   // https://vercel.com/docs/concepts/edge-network/caching
-  cacheControlHeader: 'max-age=0, s-maxage=0, stale-while-revalidate'
+  cacheControlHeader: 'max-age=0, s-maxage=0, stale-while-revalidate',
 }

--- a/config/api.config.js
+++ b/config/api.config.js
@@ -31,8 +31,8 @@ module.exports = {
 
   // Cache-Control header, check Vercel documentation for more details. The default settings imply:
   // - max-age=0: no cache for your browser
-  // - s-maxage=0: cache is fresh for 0 seconds on the edge, after which it becomes stale
+  // - s-maxage=0: cache is fresh for 60 seconds on the edge, after which it becomes stale
   // - stale-while-revalidate: allow serving stale content while revalidating on the edge
   // https://vercel.com/docs/concepts/edge-network/caching
-  cacheControlHeader: 'max-age=0, s-maxage=0, stale-while-revalidate',
+  cacheControlHeader: 'max-age=0, s-maxage=60, stale-while-revalidate',
 }

--- a/config/api.config.js
+++ b/config/api.config.js
@@ -31,8 +31,8 @@ module.exports = {
 
   // Cache-Control header, check Vercel documentation for more details. The default settings imply:
   // - max-age=0: no cache for your browser
-  // - s-maxage=3540: cache is fresh for 3540 seconds (59 minutes) on Vercel's CDN, after which it becomes stale
-  // - stale-while-revalidate=60: allow serving stale content up to another 60 seconds while revalidating
+  // - s-maxage=0: cache is fresh for 0 seconds on the edge, after which it becomes stale
+  // - stale-while-revalidate: allow serving stale content while revalidating on the edge
   // https://vercel.com/docs/concepts/edge-network/caching
-  cacheControlHeader: 'max-age=0, s-maxage=3540, stale-while-revalidate=60'
+  cacheControlHeader: 'max-age=0, s-maxage=0, stale-while-revalidate'
 }

--- a/config/api.config.js
+++ b/config/api.config.js
@@ -29,7 +29,10 @@ module.exports = {
   // unauthorised use of the proxied download feature - but that is disabled for now. So you can safely ignore this settings.
   directLinkRegex: 'public[.].*[.]files[.]1drv[.]com',
 
-  // Cache-Control header, check Vercel documentation for more details.
+  // Cache-Control header, check Vercel documentation for more details. The default settings imply:
+  // - max-age=0: no cache for your browser
+  // - s-maxage=3540: cache is fresh for 3540 seconds (59 minutes) on Vercel's CDN, after which it becomes stale
+  // - stale-while-revalidate=60: allow serving stale content up to another 60 seconds while revalidating
   // https://vercel.com/docs/concepts/edge-network/caching
-  cacheControlHeader: 'max-age=0, s-maxage=3600, stale-while-revalidate=3540'
+  cacheControlHeader: 'max-age=0, s-maxage=3540, stale-while-revalidate=60'
 }

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -2,30 +2,16 @@ import { posix as pathPosix } from 'path'
 
 import type { NextApiRequest, NextApiResponse } from 'next'
 import axios from 'axios'
-import Cors from 'cors'
 
 import apiConfig from '../../config/api.config'
 import siteConfig from '../../config/site.config'
 import { revealObfuscatedToken } from '../../utils/oAuthHandler'
 import { compareHashedToken } from '../../utils/protectedRouteHandler'
 import { getOdAuthTokens, storeOdAuthTokens } from '../../utils/odAuthTokenStore'
+import { runCorsMiddleware } from './raw'
 
 const basePath = pathPosix.resolve('/', siteConfig.baseDirectory)
 const clientSecret = revealObfuscatedToken(apiConfig.obfuscatedClientSecret)
-
-// CORS middleware for raw links: https://nextjs.org/docs/api-routes/api-middlewares
-function runCorsMiddleware(req: NextApiRequest, res: NextApiResponse) {
-  const cors = Cors({ methods: ['GET', 'HEAD'] })
-  return new Promise((resolve, reject) => {
-    cors(req, res, result => {
-      if (result instanceof Error) {
-        return reject(result)
-      }
-
-      return resolve(result)
-    })
-  })
-}
 
 /**
  * Encode the path of the file relative to the base directory
@@ -107,6 +93,64 @@ export function getAuthTokenPath(path: string) {
   return authTokenPath
 }
 
+/**
+ * Handles protected route authentication:
+ * - Match the cleanPath against an array of user defined protected routes
+ * - If a match is found:
+ * - 1. Download the .password file stored inside the protected route and parse its contents
+ * - 2. Check if the od-protected-token header is present in the request
+ * - The request is continued only if these two contents are exactly the same
+ *
+ * @param cleanPath Sanitised directory path, used for matching whether route is protected
+ * @param accessToken OneDrive API access token
+ * @param req Next.js request object
+ * @param res Next.js response object
+ */
+export async function checkAuthRoute(
+  cleanPath: string,
+  accessToken: string,
+  req: NextApiRequest
+): Promise<{ code: 200 | 401 | 404 | 500; message: string }> {
+  // Handle authentication through .password
+  const authTokenPath = getAuthTokenPath(cleanPath)
+
+  // Fetch password from remote file content
+  if (authTokenPath === '') {
+    return { code: 200, message: '' }
+  }
+
+  try {
+    const token = await axios.get(`${apiConfig.driveApi}/root${encodePath(authTokenPath)}`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      params: {
+        select: '@microsoft.graph.downloadUrl,file',
+      },
+    })
+
+    // Handle request and check for header 'od-protected-token'
+    const odProtectedToken = await axios.get(token.data['@microsoft.graph.downloadUrl'])
+    // console.log(req.headers['od-protected-token'], odProtectedToken.data.trim())
+
+    if (
+      !compareHashedToken({
+        odTokenHeader: req.headers['od-protected-token'] as string,
+        dotPassword: odProtectedToken.data,
+      })
+    ) {
+      return { code: 401, message: 'Password required for this folder.' }
+    }
+  } catch (error: any) {
+    // Password file not found, fallback to 404
+    if (error.response.status === 404) {
+      return { code: 404, message: "You didn't set a password for your protected folder." }
+    } else {
+      return { code: 500, message: 'Internal server error.' }
+    }
+  }
+
+  return { code: 200, message: 'Authenticated.' }
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   // If method is POST, then the API is called by the client to store acquired tokens
   if (req.method === 'POST') {
@@ -119,11 +163,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return
     }
 
-    await storeOdAuthTokens({
-      accessToken,
-      accessTokenExpiry,
-      refreshToken,
-    })
+    await storeOdAuthTokens({ accessToken, accessTokenExpiry, refreshToken })
     res.status(200).send('OK')
     return
   }
@@ -155,43 +195,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return
   }
 
-  // Handle authentication through .password
-  const authTokenPath = getAuthTokenPath(cleanPath)
-
-  // Fetch password from remote file content
-  if (authTokenPath !== '') {
-    // Don't server cached response for password protected folders
+  // Handle protected routes authentication
+  const { code, message } = await checkAuthRoute(cleanPath, accessToken, req)
+  // Status code other than 200 means user has not authenticated yet
+  if (code !== 200) {
+    res.status(code).json({ error: message })
+    return
+  }
+  // If message is empty, then the path is not protected.
+  // Conversely, protected routes are not allowed to serve from cache.
+  if (message !== '') {
     res.setHeader('Cache-Control', 'no-cache')
-
-    try {
-      const token = await axios.get(`${apiConfig.driveApi}/root${encodePath(authTokenPath)}`, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-        params: {
-          select: '@microsoft.graph.downloadUrl,file',
-        },
-      })
-
-      // Handle request and check for header 'od-protected-token'
-      const odProtectedToken = await axios.get(token.data['@microsoft.graph.downloadUrl'])
-      // console.log(req.headers['od-protected-token'], odProtectedToken.data.trim())
-
-      if (
-        !compareHashedToken({
-          odTokenHeader: req.headers['od-protected-token'] as string,
-          dotPassword: odProtectedToken.data,
-        })
-      ) {
-        res.status(401).json({ error: 'Password required for this folder.' })
-        return
-      }
-    } catch (error: any) {
-      // Password file not found, fallback to 404
-      if (error.response.status === 404) {
-        res.status(404).json({ error: "You didn't set a password for your protected folder." })
-      }
-      res.status(500).end()
-      return
-    }
   }
 
   const requestPath = encodePath(cleanPath)
@@ -201,24 +215,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const isRoot = requestPath === ''
 
   // Go for file raw download link, add CORS headers, and redirect to @microsoft.graph.downloadUrl
+  // (kept here for backwards compatibility, and cache headers will be reverted to no-cache)
   if (raw) {
     await runCorsMiddleware(req, res)
+    res.setHeader('Cache-Control', 'no-cache')
 
     const { data } = await axios.get(requestUrl, {
       headers: { Authorization: `Bearer ${accessToken}` },
       params: {
-        select: '@microsoft.graph.downloadUrl,folder,file',
+        select: '@microsoft.graph.downloadUrl',
       },
     })
 
-    if ('folder' in data) {
-      res.status(400).json({ error: "Folders doesn't have raw download urls." })
-      return
-    }
-    if ('file' in data) {
+    if ('@microsoft.graph.downloadUrl' in data) {
       res.redirect(data['@microsoft.graph.downloadUrl'])
       return
     }
+
+    throw { response: { status: 400, data: 'No download url found.' } }
   }
 
   // Querying current path identity (file or folder) and follow up query childrens in folder
@@ -226,7 +240,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const { data: identityData } = await axios.get(requestUrl, {
       headers: { Authorization: `Bearer ${accessToken}` },
       params: {
-        select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file,video,image',
+        select: 'name,size,id,lastModifiedDateTime,folder,file,video,image',
       },
     })
 
@@ -235,12 +249,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         headers: { Authorization: `Bearer ${accessToken}` },
         params: next
           ? {
-              select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file,video,image',
+              select: 'name,size,id,lastModifiedDateTime,folder,file,video,image',
               top: siteConfig.maxItems,
               $skipToken: next,
             }
           : {
-              select: '@microsoft.graph.downloadUrl,name,size,id,lastModifiedDateTime,folder,file,video,image',
+              select: 'name,size,id,lastModifiedDateTime,folder,file,video,image',
               top: siteConfig.maxItems,
             },
       })

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -129,7 +129,7 @@ export async function checkAuthRoute(
 
     // Handle request and check for header 'od-protected-token'
     const odProtectedToken = await axios.get(token.data['@microsoft.graph.downloadUrl'])
-    // console.log(req.headers['od-protected-token'], odProtectedToken.data.trim())
+    // console.log(odTokenHeader, odProtectedToken.data.trim())
 
     if (
       !compareHashedToken({
@@ -137,12 +137,12 @@ export async function checkAuthRoute(
         dotPassword: odProtectedToken.data,
       })
     ) {
-      return { code: 401, message: 'Password required for this folder.' }
+      return { code: 401, message: 'Password required.' }
     }
   } catch (error: any) {
     // Password file not found, fallback to 404
     if (error?.response?.status === 404) {
-      return { code: 404, message: "You didn't set a password for your protected folder." }
+      return { code: 404, message: "You didn't set a password." }
     } else {
       return { code: 500, message: 'Internal server error.' }
     }

--- a/pages/api/item.ts
+++ b/pages/api/item.ts
@@ -27,7 +27,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       })
       res.status(200).json(data)
     } catch (error: any) {
-      res.status(error.response.status).json({ error: error.response.data })
+      res.status(error?.response?.status ?? 500).json({ error: error?.response?.data ?? 'Internal server error.' })
     }
   } else {
     res.status(400).json({ error: 'Invalid driveItem ID.' })

--- a/pages/api/name/[name].ts
+++ b/pages/api/name/[name].ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { default as indexHandler } from '..'
+import { default as rawFileHandler } from '../raw'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  indexHandler(req, res)
+  rawFileHandler(req, res)
 }

--- a/pages/api/raw.ts
+++ b/pages/api/raw.ts
@@ -23,6 +23,11 @@ export function runCorsMiddleware(req: NextApiRequest, res: NextApiResponse) {
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const accessToken = await getAccessToken()
+  if (!accessToken) {
+    res.status(403).json({ error: 'No access token.' })
+    return
+  }
+
   const { path = '/', odpt = '' } = req.query
 
   // Sometimes the path parameter is defaulted to '[...path]' which we need to handle
@@ -36,12 +41,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return
   }
   const cleanPath = pathPosix.resolve('/', pathPosix.normalize(path))
-
-  // Return error 403 if access_token is empty
-  if (!accessToken) {
-    res.status(403).json({ error: 'No access token.' })
-    return
-  }
 
   // Handle protected routes authentication
   const odTokenHeader = (req.headers['od-protected-token'] as string) ?? odpt

--- a/pages/api/raw.ts
+++ b/pages/api/raw.ts
@@ -45,6 +45,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // Handle protected routes authentication
   const odTokenHeader = (req.headers['od-protected-token'] as string) ?? odpt
+
   const { code, message } = await checkAuthRoute(cleanPath, accessToken, odTokenHeader)
   // Status code other than 200 means user has not authenticated yet
   if (code !== 200) {

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -53,7 +53,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       })
       res.status(200).json(data.value)
     } catch (error: any) {
-      res.status(error.response.status).json({ error: error.response.data })
+      res.status(error?.response?.status ?? 500).json({ error: error?.response?.data ?? 'Internal server error.' })
     }
   } else {
     res.status(200).json([])

--- a/pages/api/thumbnail.ts
+++ b/pages/api/thumbnail.ts
@@ -5,19 +5,22 @@ import { posix as pathPosix } from 'path'
 import axios from 'axios'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-import { encodePath, getAccessToken, getAuthTokenPath } from '.'
+import { checkAuthRoute, encodePath, getAccessToken } from '.'
 import apiConfig from '../../config/api.config'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  // Get access token from storage
   const accessToken = await getAccessToken()
+  if (!accessToken) {
+    res.status(403).json({ error: 'No access token.' })
+    return
+  }
 
   // Get item thumbnails by its path since we will later check if it is protected
-  const { path = '', size = 'medium' } = req.query
+  const { path = '', size = 'medium', odpt = '' } = req.query
 
-  // Set edge function caching for faster load times, check docs:
+  // Set edge function caching for faster load times, if route is not protected, check docs:
   // https://vercel.com/docs/concepts/functions/edge-caching
-  res.setHeader('Cache-Control', apiConfig.cacheControlHeader)
+  if (odpt === '') res.setHeader('Cache-Control', apiConfig.cacheControlHeader)
 
   // Check whether the size is valid - must be one of 'large', 'medium', or 'small'
   if (size !== 'large' && size !== 'medium' && size !== 'small') {
@@ -36,13 +39,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
   const cleanPath = pathPosix.resolve('/', pathPosix.normalize(path))
 
-  // Check if the path is protected
-  const authTokenPath = getAuthTokenPath(cleanPath)
-
-  // Currently protected paths are rejected to avoid file content leak
-  if (authTokenPath) {
-    res.status(404).json({ error: 'Protected pathes are not allowed.' })
+  const { code, message } = await checkAuthRoute(cleanPath, accessToken, odpt as string)
+  // Status code other than 200 means user has not authenticated yet
+  if (code !== 200) {
+    res.status(code).json({ error: message })
     return
+  }
+  // If message is empty, then the path is not protected.
+  // Conversely, protected routes are not allowed to serve from cache.
+  if (message !== '') {
+    res.setHeader('Cache-Control', 'no-cache')
   }
 
   const requestPath = encodePath(cleanPath)

--- a/pages/api/thumbnail.ts
+++ b/pages/api/thumbnail.ts
@@ -63,7 +63,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       res.status(400).json({ error: "The item doesn't have a valid thumbnail." })
     }
   } catch (error: any) {
-    res.status(error.response.status).json({ error: error.response.data })
+    res.status(error?.response?.status).json({ error: error?.response?.data ?? 'Internal server error.' })
   }
   return
 }

--- a/pages/onedrive-vercel-index-oauth/step-2.tsx
+++ b/pages/onedrive-vercel-index-oauth/step-2.tsx
@@ -103,7 +103,7 @@ export default function OAuthStep2() {
 
             <p className="py-1">{t('The authorisation code extracted is:')}</p>
             <p className="my-2 overflow-hidden truncate rounded border border-gray-400/20 bg-gray-50 p-2 font-mono text-sm opacity-80 dark:bg-gray-800">
-              {authCode || <span className="animate-pulse">{t('Waiting for code...')}</span>}
+              {authCode ?? <span className="animate-pulse">{t('Waiting for code...')}</span>}
             </p>
 
             <p>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// API response object for /api?path=<path_to_file_or_folder>, this may return either a file or a folder.
+// API response object for /api/?path=<path_to_file_or_folder>, this may return either a file or a folder.
 // Pagination is also declared here with the 'next' parameter.
 export type OdAPIResponse = { file?: OdFileObject; folder?: OdFolderObject; next?: string }
 // A folder object returned from the OneDrive API. This contains the parameter 'value', which is an array of items
@@ -53,7 +53,7 @@ export type OdThumbnail = {
   medium: { height: number; width: number; url: string }
   small: { height: number; width: number; url: string }
 }
-// API response object for /api/search?q=<query>. Likewise, this array of items may also contain either files or folders.
+// API response object for /api/search/?q=<query>. Likewise, this array of items may also contain either files or folders.
 export type OdSearchResult = Array<{
   id: string
   name: string
@@ -62,7 +62,7 @@ export type OdSearchResult = Array<{
   path: string
   parentReference: { id: string; name: string; path: string }
 }>
-// API response object for /api/item?id={id}. This is primarily used for determining the path of the driveItem by ID.
+// API response object for /api/item/?id={id}. This is primarily used for determining the path of the driveItem by ID.
 export type OdDriveItem = {
   '@odata.context': string
   '@odata.etag': string

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,6 @@ export type OdFolderObject = {
   '@odata.context': string
   '@odata.nextLink'?: string
   value: Array<{
-    '@microsoft.graph.downloadUrl': string
     id: string
     name: string
     size: number
@@ -17,14 +16,11 @@ export type OdFolderObject = {
     folder?: { childCount: number; view: { sortBy: string; sortOrder: 'ascending'; viewType: 'thumbnails' } }
     image?: OdImageFile
     video?: OdVideoFile
-    // 'thumbnails@odata.context'?: string
-    // thumbnails?: Array<OdThumbnail>
   }>
 }
 export type OdFolderChildren = OdFolderObject['value'][number]
 // A file object returned from the OneDrive API. This object may contain 'video' if the file is a video.
 export type OdFileObject = {
-  '@microsoft.graph.downloadUrl': string
   '@odata.context': string
   name: string
   size: number
@@ -33,8 +29,6 @@ export type OdFileObject = {
   file: { mimeType: string; hashes: { quickXorHash: string; sha1Hash?: string; sha256Hash?: string } }
   image?: OdImageFile
   video?: OdVideoFile
-  // 'thumbnails@odata.context'?: string
-  // thumbnails?: Array<OdThumbnail>
 }
 // A representation of a OneDrive image file. Some images do not return a width and height, so types are optional.
 export type OdImageFile = {

--- a/utils/fetchOnMount.ts
+++ b/utils/fetchOnMount.ts
@@ -1,22 +1,31 @@
 import axios from 'axios'
 import { useEffect, useState } from 'react'
+import { getStoredToken } from './protectedRouteHandler'
 
-// Custom hook to axios get a URL or API endpoint on mount
-export default function useAxiosGet(fetchUrl: string): { response: any; error: string; validating: boolean } {
+/**
+ * Custom hook for axios to fetch raw file content on component mount
+ * @param fetchUrl The URL pointing to the raw file content
+ * @param path The path of the file, used for determining whether path is protected
+ */
+export default function useFileContent(
+  fetchUrl: string,
+  path: string
+): { response: any; error: string; validating: boolean } {
   const [response, setResponse] = useState('')
   const [validating, setValidating] = useState(true)
   const [error, setError] = useState('')
 
   useEffect(() => {
+    const hashedToken = getStoredToken(path)
+    const url = fetchUrl + (hashedToken ? `&odpt=${hashedToken}` : '')
+
     axios
       // Using 'blob' as response type to get the response as a raw file blob, which is later parsed as a string.
       // Axios defaults response parsing to JSON, which causes issues when parsing JSON files.
-      .get(fetchUrl, { responseType: 'blob' })
+      .get(url, { responseType: 'blob' })
       .then(async res => setResponse(await res.data.text()))
       .catch(e => setError(e.message))
-      .finally(() => {
-        setValidating(false)
-      })
-  }, [fetchUrl])
+      .finally(() => setValidating(false))
+  }, [fetchUrl, path])
   return { response, error, validating }
 }

--- a/utils/fetchWithSWR.ts
+++ b/utils/fetchWithSWR.ts
@@ -40,10 +40,10 @@ export function useProtectedSWRInfinite(path: string = '') {
     if (previousPageData && !previousPageData.folder) return null
 
     // First page with no prevPageData
-    if (pageIndex === 0) return [`/api?path=${path}`, hashedToken]
+    if (pageIndex === 0) return [`/api/?path=${path}`, hashedToken]
 
     // Add nextPage token to API endpoint
-    return [`/api?path=${path}&next=${previousPageData.next}`, hashedToken]
+    return [`/api/?path=${path}&next=${previousPageData.next}`, hashedToken]
   }
 
   // Disable auto-revalidate, these options are equivalent to useSWRImmutable

--- a/utils/oAuthHandler.ts
+++ b/utils/oAuthHandler.ts
@@ -43,7 +43,7 @@ export function extractAuthCodeFromRedirected(url: string): string {
 
   // New URL search parameter
   const params = new URLSearchParams(url.split('?')[1])
-  return params.get('code') || ''
+  return params.get('code') ?? ''
 }
 
 // After a successful authorisation, the code returned from the Microsoft OAuth 2.0 authorization URL


### PR DESCRIPTION
- [x] Raw files are now served on a different route: `/api?path=<file>&raw=true` === `/api/raw?path=<file>`
- [x] Protected routes accept either `od-protected-token` as header, or URL parameter `&odpt=<hashed_token>`
- [x] All file preview renderings are now using the new raw file route instead of the original OneDrive provided URL.
- [x] All thumbnails are now accepting the same URL parameter used for authentication.
- [x] API calls are now suffixed with trailing slashes to avoid an extra redirect.
- [x] Also, a few fixes `||` -> `??`, and a few error handling adjustments.

cc @myl7 @Android-KitKat 