### PR TITLE
Fix readable URL character filtering

### DIFF
--- a/utils/getReadablePath.ts
+++ b/utils/getReadablePath.ts
@@ -13,11 +13,6 @@ export function getReadablePath(path: string) {
         .join('')
     )
     .join('/')
-  // Handle trailing char for autolink
-  // Ref: https://github.github.com/gfm/#autolinks-extension-
-  if (/^[!,:*]$/.test(path[path.length - 1])) {
-    path = path.substring(0, path.length - 1) + encodeURIComponent(path[path.length - 1])
-  }
   return path
 }
 
@@ -28,7 +23,7 @@ function isSafeChar(c: string) {
     if (/^[a-zA-Z0-9\-._~]$/.test(c)) {
       // RFC3986 unreserved chars
       return true
-    } else if (/^[*:+@,!]$/.test(c)) {
+    } else if (/^[*:@,!]$/.test(c)) {
       // Some extra pretty safe chars for URL path or query
       // Ref: https://stackoverflow.com/a/42287988/11691878
       return true


### PR DESCRIPTION
Closes #464

The PR removes `+` out of the kept charset. For other kept chars `[*:@,!]` I have done tests on Chrome address bar to ensure it can auto-encode them correctly as even query params.

The PR also removes trailing handling which aims to fullfill autolink, since there may be other chars (not encoded, which is required by RFC) that can still break autolink.