### PR TITLE
Make filename inputbox default value in custom link menu readable

### DIFF
--- a/components/CustomEmbedLinkMenu.tsx
+++ b/components/CustomEmbedLinkMenu.tsx
@@ -27,7 +27,8 @@ export default function CustomEmbedLinkMenu({
   const focusInputRef = useRef<HTMLInputElement>(null)
   const closeMenu = () => setMenuOpen(false)
 
-  const filename = path.substring(path.lastIndexOf('/') + 1)
+  const readablePath = getReadablePath(path)
+  const filename = readablePath.substring(readablePath.lastIndexOf('/') + 1)
   const [name, setName] = useState(filename)
 
   return (
@@ -85,13 +86,13 @@ export default function CustomEmbedLinkMenu({
                 />
                 <h4 className="py-2 text-xs font-medium uppercase tracking-wider">{t('Default')}</h4>
                 <div className="mb-2 overflow-hidden break-all rounded border border-gray-400/20 bg-gray-50 p-1 font-mono dark:bg-gray-800">
-                  {`${getBaseUrl()}/api/raw/?path=${getReadablePath(path)}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
+                  {`${getBaseUrl()}/api/raw/?path=${readablePath}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
                 </div>
                 <h4 className="py-2 text-xs font-medium uppercase tracking-wider">{t('Customised')}</h4>
                 <div className="mb-2 overflow-hidden break-all rounded border border-gray-400/20 bg-gray-50 p-1 font-mono dark:bg-gray-800">
                   <span>{`${getBaseUrl()}/api/name/`}</span>
                   <span className="underline decoration-blue-400 decoration-wavy">{name}</span>
-                  <span>{`/?path=${getReadablePath(path)}${hashedToken ? `&odpt=${hashedToken}` : ''}`}</span>
+                  <span>{`/?path=${readablePath}${hashedToken ? `&odpt=${hashedToken}` : ''}`}</span>
                 </div>
               </div>
 
@@ -100,7 +101,7 @@ export default function CustomEmbedLinkMenu({
                   className="rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 px-4 py-2 text-center text-sm font-medium text-white hover:bg-gradient-to-bl focus:ring-4 focus:ring-cyan-300 dark:focus:ring-cyan-800"
                   onClick={() => {
                     clipboard.copy(
-                      `${getBaseUrl()}/api/name/${name}/?path=${getReadablePath(path)}${
+                      `${getBaseUrl()}/api/name/${name}/?path=${readablePath}${
                         hashedToken ? `&odpt=${hashedToken}` : ''
                       }`
                     )


### PR DESCRIPTION
The PR makes the default value of filename inputbox in custom link menu become the final component of the readable URL other than the original URL. The customized can still keep browser-level valid since the whole readable path is.