### PR TITLE
add files list filtering

### DIFF
--- a/components/FolderGridLayout.tsx
+++ b/components/FolderGridLayout.tsx
@@ -10,6 +10,7 @@ import { getBaseUrl } from '../utils/getBaseUrl'
 import { formatModifiedDateTime } from '../utils/fileDetails'
 import { Checkbox, ChildIcon, ChildName, Downloading } from './FileListing'
 import { getStoredToken } from '../utils/protectedRouteHandler'
+import { hideFileRegex } from '../config/api.config'
 
 const GridItem = ({ c, path }: { c: OdFolderChildren; path: string }) => {
   // We use the generated medium thumbnail for rendering preview images (excluding folders)
@@ -74,6 +75,7 @@ const FolderGridLayout = ({
 
   // Get item path from item name
   const getItemPath = (name: string) => `${path === '/' ? '' : path}/${encodeURIComponent(name)}`
+  folderChildren = folderChildren.filter((c: OdFolderChildren) => c.name.match(new RegExp(hideFileRegex,'i')) === null)
 
   return (
     <div className="rounded bg-white dark:bg-gray-900 dark:text-gray-100">

--- a/components/FolderGridLayout.tsx
+++ b/components/FolderGridLayout.tsx
@@ -75,7 +75,7 @@ const FolderGridLayout = ({
 
   // Get item path from item name
   const getItemPath = (name: string) => `${path === '/' ? '' : path}/${encodeURIComponent(name)}`
-  folderChildren = folderChildren.filter((c: OdFolderChildren) => c.name.match(new RegExp(hideFileRegex,'i')) === null)
+  folderChildren = folderChildren.filter((c: OdFolderChildren) => c.name.match(new RegExp(hideFileRegex, 'i')) === null)
 
   return (
     <div className="rounded bg-white dark:bg-gray-900 dark:text-gray-100">
@@ -141,8 +141,7 @@ const FolderGridLayout = ({
                     className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
                     onClick={() => {
                       clipboard.copy(
-                        `${getBaseUrl()}/api/raw/?path=${getItemPath(c.name)}${
-                          hashedToken ? `&odpt=${hashedToken}` : ''
+                        `${getBaseUrl()}/api/raw/?path=${getItemPath(c.name)}${hashedToken ? `&odpt=${hashedToken}` : ''
                         }`
                       )
                       toast.success(t('Copied raw file permalink.'))
@@ -153,9 +152,8 @@ const FolderGridLayout = ({
                   <a
                     title={t('Download file')}
                     className="cursor-pointer rounded px-1.5 py-1 hover:bg-gray-300 dark:hover:bg-gray-600"
-                    href={`${getBaseUrl()}/api/raw/?path=${getItemPath(c.name)}${
-                      hashedToken ? `&odpt=${hashedToken}` : ''
-                    }`}
+                    href={`${getBaseUrl()}/api/raw/?path=${getItemPath(c.name)}${hashedToken ? `&odpt=${hashedToken}` : ''
+                      }`}
                   >
                     <FontAwesomeIcon icon={['far', 'arrow-alt-circle-down']} />
                   </a>
@@ -164,9 +162,8 @@ const FolderGridLayout = ({
             </div>
 
             <div
-              className={`${
-                selected[c.id] ? 'opacity-100' : 'opacity-0'
-              } absolute top-0 left-0 z-10 m-1 rounded bg-white/50 py-0.5 group-hover:opacity-100 dark:bg-gray-900/50`}
+              className={`${selected[c.id] ? 'opacity-100' : 'opacity-0'
+                } absolute top-0 left-0 z-10 m-1 rounded bg-white/50 py-0.5 group-hover:opacity-100 dark:bg-gray-900/50`}
             >
               {!c.folder && !(c.name === '.password') && (
                 <Checkbox

--- a/components/FolderListLayout.tsx
+++ b/components/FolderListLayout.tsx
@@ -11,6 +11,7 @@ import { humanFileSize, formatModifiedDateTime } from '../utils/fileDetails'
 
 import { Downloading, Checkbox, ChildIcon, ChildName } from './FileListing'
 import { getStoredToken } from '../utils/protectedRouteHandler'
+import { hideFileRegex } from '../config/api.config'
 
 const FileListItem: FC<{ fileContent: OdFolderChildren }> = ({ fileContent: c }) => {
   return (
@@ -51,6 +52,7 @@ const FolderListLayout = ({
 
   // Get item path from item name
   const getItemPath = (name: string) => `${path === '/' ? '' : path}/${encodeURIComponent(name)}`
+  folderChildren = folderChildren.filter((c: OdFolderChildren) => c.name.match(new RegExp(hideFileRegex,'i')) === null)
 
   return (
     <div className="rounded bg-white dark:bg-gray-900 dark:text-gray-100">

--- a/components/FolderListLayout.tsx
+++ b/components/FolderListLayout.tsx
@@ -52,7 +52,7 @@ const FolderListLayout = ({
 
   // Get item path from item name
   const getItemPath = (name: string) => `${path === '/' ? '' : path}/${encodeURIComponent(name)}`
-  folderChildren = folderChildren.filter((c: OdFolderChildren) => c.name.match(new RegExp(hideFileRegex,'i')) === null)
+  folderChildren = folderChildren.filter((c: OdFolderChildren) => c.name.match(new RegExp(hideFileRegex, 'i')) === null)
 
   return (
     <div className="rounded bg-white dark:bg-gray-900 dark:text-gray-100">

--- a/config/api.config.js
+++ b/config/api.config.js
@@ -31,7 +31,7 @@ module.exports = {
 
   // The hideFileRegex is used to hide some files, and supports regular expressions. e.g. README.md
   hideFileRegex: 'README[.]md',
-  
+
   // Cache-Control header, check Vercel documentation for more details. The default settings imply:
   // - max-age=0: no cache for your browser
   // - s-maxage=0: cache is fresh for 60 seconds on the edge, after which it becomes stale

--- a/config/api.config.js
+++ b/config/api.config.js
@@ -29,6 +29,9 @@ module.exports = {
   // unauthorised use of the proxied download feature - but that is disabled for now. So you can safely ignore this settings.
   directLinkRegex: 'public[.].*[.]files[.]1drv[.]com',
 
+  // The hideFileRegex is used to hide some files, and supports regular expressions. e.g. README.md
+  hideFileRegex: 'README[.]md',
+  
   // Cache-Control header, check Vercel documentation for more details. The default settings imply:
   // - max-age=0: no cache for your browser
   // - s-maxage=0: cache is fresh for 60 seconds on the edge, after which it becomes stale


### PR DESCRIPTION
增加一个配置项 `hideFileRegex` 用来在列表隐藏某些不想显示的文件，
\
例如某些文件仅想用直链分享，并不想展示在列表上(加密的文件手动进入后获取带`hashedToken`的链接可分享，不展示)

例如 `README.md` 存在没有意义(本程序并没有编辑功能)