### PR TITLE
fix filename not recognized in generated custom link

### DIFF
--- a/components/CustomEmbedLinkMenu.tsx
+++ b/components/CustomEmbedLinkMenu.tsx
@@ -111,13 +111,13 @@ export default function CustomEmbedLinkMenu({
                 />
                 <LinkContainer
                   title={t('Customised')}
-                  value={`${getBaseUrl()}/api/name/${name}/?path=${readablePath}${
+                  value={`${getBaseUrl()}/api/name/${name}?path=${readablePath}${
                     hashedToken ? `&odpt=${hashedToken}` : ''
                   }`}
                 />
                 <LinkContainer
                   title={t('Customised and encoded')}
-                  value={`${getBaseUrl()}/api/name/${name}/?path=${path}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
+                  value={`${getBaseUrl()}/api/name/${name}?path=${path}${hashedToken ? `&odpt=${hashedToken}` : ''}`}
                 />
               </div>
             </div>


### PR DESCRIPTION
remove redundant ending slash so that filename can be recognized.

For example: in `https://.../api/name/somevideo.mp4/?path=/somevideo.mp4`, the file name is not the final path, so it won't be recognized. Manually removing the ending slash (`https://.../api/name/somevideo.mp4?path=/somevideo.mp4`) fixes this problem (tested in notion). 