### PR TITLE
Fix numeric password not working

### DIFF
--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -134,7 +134,7 @@ export async function checkAuthRoute(
     if (
       !compareHashedToken({
         odTokenHeader: odTokenHeader,
-        dotPassword: odProtectedToken.data,
+        dotPassword: odProtectedToken.data.toString(),
       })
     ) {
       return { code: 401, message: 'Password required.' }


### PR DESCRIPTION
Closes #606

`data` of axios responses is JSON-parsed, which causes numeric password is unexpectedly recognized as integers.