### PR TITLE
Fix imports from `fontawesome-common-types` for clean build

### DIFF
--- a/utils/getFileIcon.ts
+++ b/utils/getFileIcon.ts
@@ -1,4 +1,4 @@
-import type { IconPrefix, IconName } from '@fortawesome/fontawesome-common-types'
+import type { IconPrefix, IconName } from '@fortawesome/fontawesome-svg-core'
 
 const icons: { [key: string]: [IconPrefix, IconName] } = {
   image: ['far', 'file-image'],


### PR DESCRIPTION
According to the description of [`@fortawesome/fontawesome-common-types`](https://www.npmjs.com/package/@fortawesome/fontawesome-common-types):

> If you are trying to import types from this package we highly recommend you do the following instead as all types in this package are re-exported to the main fontawesome package.
> ```js
> import { IconName } from `@fortawesome/fontawesome-svg-core`
> ```

Actually when building the project in a `node:18-alpine` Docker container, `next build` will complain the compiler SWC can not find types of `@fortawesome/fontawesome-common-types` and fails, but `@fortawesome/fontawesome-svg-core` will be OK. The PR may help users who want to build the project in a container to selfhost it.