### PR TITLE
Docker build config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/.git
+**/node_modules
+**/.vscode
+**/.idea
+**/.next
+**/.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18-alpine
+WORKDIR /app
+RUN npm install -g pnpm
+COPY ./ /app/
+# Unmet peer dependencies occurs but seems not to break the app
+RUN pnpm install || true
+# Suggested by Next.js if you use next/image
+RUN pnpm add sharp
+RUN pnpm build
+ENTRYPOINT [ "pnpm", "run", "start" ]
+EXPOSE 3000


### PR DESCRIPTION
Since there are many hot discussions about selfhosting the project (disscussion #595 #633 #518), the PR adds some simple Docker build config for the project, to help users serve the project with Docker by themselves easily.

To serve the project, build the Docker image and run it like:

```bash
docker build -t onedrive-vercel-index .
docker run -d --restart=unless-stopped --name=<...> -p <...>:3000 -e REDIS_URL=<...> onedrive-vercel-index
```

One problem is that since the 2 config files are bundled, when the config files change the Docker image needs to be rebuilt.

There is a similar discussion #112 having talked about selfhosting deployment, but times goes by and many components changed. I would suggest including the selfhosting deployment config into the repo for better maintanance.