### PR TITLE
Fix error report for search result item requests

### DIFF
--- a/components/SearchModal.tsx
+++ b/components/SearchModal.tsx
@@ -113,12 +113,22 @@ function SearchResultItemTemplate({
 }
 
 function SearchResultItemLoadRemote({ result }: { result: OdSearchResult[number] }) {
-  const { data, error }: SWRResponse<OdDriveItem, string> = useSWR(`/api/item/?id=${result.id}`, fetcher)
+  const { data, error }: SWRResponse<OdDriveItem, { status: number; message: any }> = useSWR(
+    `/api/item/?id=${result.id}`,
+    fetcher
+  )
 
   const { t } = useTranslation()
 
   if (error) {
-    return <SearchResultItemTemplate driveItem={result} driveItemPath={''} itemDescription={error} disabled={true} />
+    return (
+      <SearchResultItemTemplate
+        driveItem={result}
+        driveItemPath={''}
+        itemDescription={typeof error.message?.error === 'string' ? error.message.error : JSON.stringify(error.message)}
+        disabled={true}
+      />
+    )
   }
   if (!data) {
     return (


### PR DESCRIPTION
According to

https://github.com/spencerwooo/onedrive-vercel-index/blob/152380bd057d256bcd6cf3ececefcf5826fecaf9/utils/fetchWithSWR.ts#L18-L20

When an error occurs from item API, as for the error reporting code

https://github.com/spencerwooo/onedrive-vercel-index/blob/152380bd057d256bcd6cf3ececefcf5826fecaf9/components/SearchModal.tsx#L116

here `error` is not a `string` but `{ status: number; message: any }`

Since the error object is passed into the sub component like

https://github.com/spencerwooo/onedrive-vercel-index/blob/152380bd057d256bcd6cf3ececefcf5826fecaf9/components/SearchModal.tsx#L121

And the `itemDescription` prop is directly used in `{}` like

https://github.com/spencerwooo/onedrive-vercel-index/blob/152380bd057d256bcd6cf3ececefcf5826fecaf9/components/SearchModal.tsx#L106-L108

which is disallowed for an object other than a string, a React children-related error will be raised if the item API returns an error, which is fixed in the PR.