### PR TITLE
Filter out protected ones from search results

### DIFF
--- a/components/SearchModal.tsx
+++ b/components/SearchModal.tsx
@@ -15,28 +15,7 @@ import { LoadingIcon } from './Loading'
 
 import { getFileIcon } from '../utils/getFileIcon'
 import { fetcher } from '../utils/fetchWithSWR'
-import siteConfig from '../config/site.config'
-
-/**
- * Extract the searched item's path in field 'parentReference' and convert it to the
- * absolute path represented in onedrive-vercel-index
- *
- * @param path Path returned from the parentReference field of the driveItem
- * @returns The absolute path of the driveItem in the search result
- */
-function mapAbsolutePath(path: string): string {
-  // path is in the format of '/drive/root:/path/to/file', if baseDirectory is '/' then we split on 'root:',
-  // otherwise we split on the user defined 'baseDirectory'
-  const absolutePath = path.split(siteConfig.baseDirectory === '/' ? 'root:' : siteConfig.baseDirectory)
-  // path returned by the API may contain #, by doing a decodeURIComponent and then encodeURIComponent we can
-  // replace URL sensitive characters such as the # with %23
-  return absolutePath.length > 1 // solve https://github.com/spencerwooo/onedrive-vercel-index/issues/539
-    ? absolutePath[1]
-        .split('/')
-        .map(p => encodeURIComponent(decodeURIComponent(p)))
-        .join('/')
-    : ''
-}
+import { mapAbsolutePath } from '../utils/mapAbsolutePath'
 
 /**
  * Implements a debounced search function that returns a promise that resolves to an array of

--- a/pages/api/item.ts
+++ b/pages/api/item.ts
@@ -1,8 +1,10 @@
 import axios from 'axios'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-import { getAccessToken } from '.'
+import { getAccessToken, getAuthTokenPath } from '.'
 import apiConfig from '../../config/api.config'
+import type { OdDriveItem } from '../../types'
+import { mapAbsolutePath } from '../../utils/mapAbsolutePath'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   // Get access token from storage
@@ -25,6 +27,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           select: 'id,name,parentReference',
         },
       })
+
+      // Check if path of the item are protected
+      const item = data as OdDriveItem
+      const path = `${decodeURIComponent(mapAbsolutePath(item.parentReference.path))}/${item.name}`
+      if (getAuthTokenPath(path) !== '') {
+        res.status(403).json({ error: 'The driveItem is password protected.' })
+        return
+      }
+
       res.status(200).json(data)
     } catch (error: any) {
       res.status(error?.response?.status ?? 500).json({ error: error?.response?.data ?? 'Internal server error.' })

--- a/utils/mapAbsolutePath.ts
+++ b/utils/mapAbsolutePath.ts
@@ -1,0 +1,22 @@
+import siteConfig from '../config/site.config'
+
+/**
+ * Extract the searched item's path in field 'parentReference' and convert it to the
+ * absolute path represented in onedrive-vercel-index
+ *
+ * @param path Path returned from the parentReference field of the driveItem
+ * @returns The absolute path of the driveItem in the search result
+ */
+export function mapAbsolutePath(path: string): string {
+  // path is in the format of '/drive/root:/path/to/file', if baseDirectory is '/' then we split on 'root:',
+  // otherwise we split on the user defined 'baseDirectory'
+  const absolutePath = path.split(siteConfig.baseDirectory === '/' ? 'root:' : siteConfig.baseDirectory)
+  // path returned by the API may contain #, by doing a decodeURIComponent and then encodeURIComponent we can
+  // replace URL sensitive characters such as the # with %23
+  return absolutePath.length > 1 // solve https://github.com/spencerwooo/onedrive-vercel-index/issues/539
+    ? absolutePath[1]
+        .split('/')
+        .map(p => encodeURIComponent(decodeURIComponent(p)))
+        .join('/')
+    : ''
+}


### PR DESCRIPTION
Since excluding protected routes from searching is a long-proposed feature (#356 #618), the PR trys to provide a way to visually-only limit search results.
While perfect protection is almost impossible which is talked already at #283, some visually tricks may help to at least block "attackers" who do not even know F12.
API results though are filtered as far as the app can, but may still expose filenames of protected files, while the correspoinding protected folder path is hidden.
Further development, such as hiding the search result items that are recognized to be protected ones as long as its path is got, requires error handling fix #647 to differ different errors, so the PR is kept as a draft.