### PR TITLE
support ios safari fullscreen

### DIFF
--- a/components/previews/VideoPreview.tsx
+++ b/components/previews/VideoPreview.tsx
@@ -65,6 +65,7 @@ const VideoPlayer: FC<{
   }
   const plyrOptions: Plyr.Options = {
     ratio: `${width ?? 16}:${height ?? 9}`,
+    fullscreen: { iosNative: true },
   }
   if (!isFlv) {
     // If the video is not in flv format, we can use the native plyr and add sources directly with the video URL


### PR DESCRIPTION
related issues #611
discussions #579

This will allow video previews on iOS to use the system's full screen while taking advantage of iOS' picture-in-picture feature, as well as the ability to change the speed of video playback using the system player on iOS 15+.
However, subtitles will not be visible in full screen this way, even if the Show subtitles option is available and turned on in the system player.


But I think there are probably more people who need iOS full screen than subtitles, so maybe we need to find another way to fix the subtitle problem.😂