### PR TITLE
✨ feat: 添加导航栏标题

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -67,7 +67,7 @@ const Navbar = () => {
         <Link href="/" passHref>
           <a className="flex items-center space-x-2 py-2 hover:opacity-80 dark:text-white md:p-2">
             <Image src={siteConfig.icon} alt="icon" width="25" height="25" priority />
-            <span className="hidden font-bold sm:block">{siteConfig.title}</span>
+            <span className="hidden font-bold sm:block">{siteConfig.header}</span>
           </a>
         </Link>
 

--- a/config/site.config.js
+++ b/config/site.config.js
@@ -16,8 +16,11 @@ module.exports = {
   // Prefix for KV Storage
   kvPrefix: process.env.KV_PREFIX || '',
 
-  // The name of your website. Present alongside your icon.
+  // The title of the website. Present in the navigation bar and the title of the page.
   title: "Spencer's OneDrive",
+  // The name of your website. Present alongside your icon.
+  header: "Spencer's OneDrive",
+
 
   // The folder that you are to share publicly with onedrive-vercel-index. Use '/' if you want to share your root folder.
   baseDirectory: '/',

--- a/pages/onedrive-vercel-index-oauth/step-1.tsx
+++ b/pages/onedrive-vercel-index-oauth/step-1.tsx
@@ -18,7 +18,7 @@ export default function OAuthStep1() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-white dark:bg-gray-900">
       <Head>
-        <title>{t('OAuth Step 1 - {{title}}', { title: siteConfig.title })}</title>
+        <title>{t('OAuth Step 1 - {{title}}', { title: siteConfig.header })}</title>
       </Head>
 
       <main className="flex w-full flex-1 flex-col bg-gray-50 dark:bg-gray-800">

--- a/pages/onedrive-vercel-index-oauth/step-2.tsx
+++ b/pages/onedrive-vercel-index-oauth/step-2.tsx
@@ -26,7 +26,7 @@ export default function OAuthStep2() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-white dark:bg-gray-900">
       <Head>
-        <title>{t('OAuth Step 2 - {{title}}', { title: siteConfig.title })}</title>
+        <title>{t('OAuth Step 2 - {{title}}', { title: siteConfig.header })}</title>
       </Head>
 
       <main className="flex w-full flex-1 flex-col bg-gray-50 dark:bg-gray-800">

--- a/pages/onedrive-vercel-index-oauth/step-3.tsx
+++ b/pages/onedrive-vercel-index-oauth/step-3.tsx
@@ -90,7 +90,7 @@ export default function OAuthStep3({ accessToken, expiryTime, refreshToken, erro
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-white dark:bg-gray-900">
       <Head>
-        <title>{t('OAuth Step 3 - {{title}}', { title: siteConfig.title })}</title>
+        <title>{t('OAuth Step 3 - {{title}}', { title: siteConfig.header })}</title>
       </Head>
 
       <main className="flex w-full flex-1 flex-col bg-gray-50 dark:bg-gray-800">


### PR DESCRIPTION
在`site.config.js`中添加`header`配置，用于区分页面的title和header中的标题，演示如下：
![image](https://user-images.githubusercontent.com/52142762/184951172-25710b8c-ca36-4752-9d23-5ba751609cf5.png)