### PR TITLE
Fix audio preview covers style when is not square

### DIFF
--- a/src/components/previews/AudioPreview.tsx
+++ b/src/components/previews/AudioPreview.tsx
@@ -66,7 +66,7 @@ const AudioPreview: FC<{ file: OdFileObject }> = ({ file }) => {
             </div>
 
             {!brokenThumbnail ? (
-              <div className="absolute m-4 rounded-full shadow-lg">
+              <div className="absolute m-4 rounded-full shadow-lg aspect-square">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   className={`h-full w-full rounded-full object-cover object-top ${


### PR DESCRIPTION
### Description

#473 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<!-- ### Linked Issues -->

<!-- Please reference the issue that it solves if there is any (e.g. `fixes #123`) -->

### Additional context

Before:
![image](https://user-images.githubusercontent.com/30021379/214809973-d7968163-fcc3-4672-85d9-827f18d5784a.png)


After:
![image](https://user-images.githubusercontent.com/30021379/214810111-ca3df4ec-4a12-4025-8c9e-4b02b19784ea.png)

<!-- e.g. is there anything you'd like reviewers to focus on? -->
