### PR TITLE
Vercel analytics support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@headlessui/react": "^1.7.8",
     "@tailwindcss/line-clamp": "^0.4.2",
+    "@vercel/analytics": "^1.0.1",
     "awesome-debounce-promise": "^2.1.0",
     "axios": "^1.2.6",
     "cors": "^2.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   '@tailwindcss/line-clamp':
     specifier: ^0.4.2
     version: 0.4.2(tailwindcss@3.2.4)
+  '@vercel/analytics':
+    specifier: ^1.0.1
+    version: 1.0.1
   awesome-debounce-promise:
     specifier: ^2.1.0
     version: 2.1.0
@@ -888,6 +891,10 @@ packages:
       '@typescript-eslint/types': 5.49.0
       eslint-visitor-keys: 3.4.1
     dev: true
+
+  /@vercel/analytics@1.0.1:
+    resolution: {integrity: sha512-Ux0c9qUfkcPqng3vrR0GTrlQdqNJ2JREn/2ydrVuKwM3RtMfF2mWX31Ijqo1opSjNAq6rK76PwtANw6kl6TAow==}
+    dev: false
 
   /@xmldom/xmldom@0.7.9:
     resolution: {integrity: sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import '@fortawesome/fontawesome-svg-core/styles.css'
 
 import '../styles/globals.css'
 import '../styles/markdown-github.css'
+import { Analytics } from '@vercel/analytics/react';
 
 // Require had to be used to prevent SSR failure in Next.js
 // Related discussion: https://github.com/FortAwesome/Font-Awesome/issues/19348
@@ -123,6 +124,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <NextNProgress height={1} color="rgb(156, 163, 175, 0.9)" options={{ showSpinner: false }} />
+      <Analytics />
       <Component {...pageProps} />
     </>
   )


### PR DESCRIPTION
### Description

Added support for Vercel analytics by using [their package](https://www.npmjs.com/package/@vercel/analytics). This will allow users to track page views and other stats from their Vercel dashboard.